### PR TITLE
Update fci.py

### DIFF
--- a/pyqed/qchem/ci/fci.py
+++ b/pyqed/qchem/ci/fci.py
@@ -267,7 +267,7 @@ def get_excitation_op(i, j, binary, sign, spin=0):
 
     # print(a.shape, a_t.shape)
 
-        # return a_t, a
+            return a_t, a
 
     return sign[j, spin]*a_t, sign[i, spin]*a
 


### PR DESCRIPTION
fix bug in get_excitation_op to get correct SlaterCondon rule in fci.py, spin contamination in casci is gone now.