### PR TITLE
add primitive state average dmrgscf

### DIFF
--- a/examples/qchem/dmrgscf.py
+++ b/examples/qchem/dmrgscf.py
@@ -6,7 +6,7 @@ mol.build(driver='pyscf')
 
 mf = mol.RHF().run()
 
-mc = DMRGSCF(mf, ncas=6, nelecas=6, D=60, max_cycles=50)
+mc = DMRGSCF(mf, ncas=4, nelecas=4, D=60, max_cycles=50)
 
 mc.fix_spin(ss=0, shift=0.2)
 mc.run(

--- a/examples/qchem/dmrgscf.py
+++ b/examples/qchem/dmrgscf.py
@@ -1,0 +1,16 @@
+from pyqed import Molecule
+from pyqed.qchem.dmrg.dmrgscf import DMRGSCF
+
+mol = Molecule(atom='Li 0 0 0; F 0 0 1.4', unit='b', basis='6311g')
+mol.build(driver='pyscf')
+
+mf = mol.RHF().run()
+
+mc = DMRGSCF(mf, ncas=6, nelecas=6, D=60, max_cycles=50)
+
+mc.fix_spin(ss=0, shift=0.2)
+mc.run(
+    nstates=2,
+    symmetry_list=['charge', 'sz'], 
+    initial_guess='cid'
+)

--- a/pyqed/mps/dmrg.py
+++ b/pyqed/mps/dmrg.py
@@ -24,42 +24,42 @@ class DMRG:
     """
     def __init__(self, H, D, init_guess=None, nsweeps=50, opt='2site',\
                 symmetry=False, charge=None, spin = None,\
-                target_qn = None, sym_mgr = None, not_conv_err=True):
+                target_qn = None, sym_mgr = None, not_conv_err=True,
+                nstates=1, weights=None): # [FIX] Added nstates and weights
         """
-
-
         Parameters
         ----------
-        H : TYPE
-            MPO of H.
-        D : TYPE
+        H : MPO
+            MPO of the Hamiltonian.
+        D : int
             maximum bond dimension.
-        nsweeps : TYPE, optional
-            DESCRIPTION. The default is None.
-        init_guess : TYPE, optional
-            DESCRIPTION. The default is None.
-
-        Returns
-        -------
-        None.
-
+        nsweeps : int
+            Number of sweeps to perform.
+        nstates : int
+            Number of states for State-Averaged DMRG.
+        weights : list
+            Weights for state averaging.
         """
 
         self.H = H
-        # self.L = self.H.L
+        self.L = len(self.H)
         self.D = D
         self.nsweeps = nsweeps
         self.opt = opt
 
         self.init_guess = init_guess
-        self.mps = None
         self.e_tot = None
         self.U1 = self.symmetry = symmetry
+        
 
+        self.nstates = nstates
+        self.weights = weights if weights is not None else [1.0/nstates]*nstates
+
+        # Symmetry Logic
         if target_qn is not None and (sym_mgr is None):
-            raise ValueError("Symmetry manager must be provided when target quantum number is specified as QN object.")
+            raise ValueError("Symmetry manager must be provided when target quantum number is specified.")
         elif target_qn is None and sym_mgr is not None:
-            raise ValueError("Target quantum number must be specified when sym_mgr is given. If you are restricting symmetry by charge and spin, don't need to input sym_mgr to avoid conflict.")
+            raise ValueError("Target quantum number must be specified when sym_mgr is given.")
         elif (charge is not None) and (spin is not None):
             sym_mgr = SymmetryManager(['charge', 'sz'])
             target_qn = sym_mgr.get_target_qn(charge, 2*spin)
@@ -71,16 +71,13 @@ class DMRG:
             target_qn = sym_mgr.get_target_qn(2*spin)
             
         self.charge = charge
-
-        self.ground_state = None
-        self.mps = None # to hold eigenstates
-        
-        # self.ground_state_raw = None
-
-        self.not_conv_err = not_conv_err
-        self.converged = False
         self.target_qn = target_qn 
         self.sym_mgr = sym_mgr
+
+        self.ground_state = None # Holds Root 0
+        self.states = None       # Holds list of all Roots
+        self.not_conv_err = not_conv_err
+        self.converged = False
 
     def run(self):
 
@@ -96,62 +93,45 @@ class DMRG:
             # If it's a raw list, we assume it respects the convention. TODO: maybe add auto check and warning and raise error.
             mps_list = self.init_guess
 
-        if isinstance(self.H, MPO):
-            mpo_list = self.H.factors
-        else:
-            mpo_list = self.H
+        mpo_list = self.H.factors if isinstance(self.H, MPO) else self.H
 
-        if self.symmetry:
-
-            if isinstance(mps_list, list) and not \
-                isinstance(mps_list[0], BlockTensor):
-
-                mps_list = dense_to_symmetric(mps_list, phys_qns=None)
-
-            if self.target_qn is not None:
-
-                qs = sorted({key[1] for key in mps_list[-1].data.keys()})
-                if len(qs) != 1:
-                    raise ValueError(f"Ambiguous total charge: {qs}.")
-                self.target_qn = qs[0]
+        if self.symmetry and not isinstance(mps_list[0], BlockTensor):
+            mps_list = dense_to_symmetric(mps_list, sym_mgr=self.sym_mgr)
 
         if self.opt == '1site':
 
             fDMRG_1site_GS_OBC(mpo_list, self.D, self.nsweeps)
 
         elif self.opt == '2site':
+            res = two_site_dmrg(
+                mps_list, mpo_list, self.D, self.nsweeps, 
+                U1=self.U1, target_qn=self.target_qn, 
+                not_conv_err=self.not_conv_err, sym_mgr=self.sym_mgr,
+                nstates=self.nstates, weights=self.weights
+            )
+            e_elec, mps_out, self.gauge, self.converged = res
 
-            self.e_tot, ground_state, self.gauge, self.converged = two_site_dmrg(
-                mps_list, mpo_list, self.D, self.nsweeps, \
-                    U1=self.U1, target_qn=self.target_qn, not_conv_err=self.not_conv_err, sym_mgr=self.sym_mgr)
-
-            if self.U1:
-                # U1 engine returns [Left, Right, Phys]
-                labels = ['lv', 'rv', 'p']
-            else:
-                # Dense engine returns [Left, Phys, Right]
-                labels = ['lv', 'p', 'rv']
+            shift = getattr(self.H, 'constant', 0.0)
             
-            # self.ground_state = self.mps = MPS(ground_state, labels=labels, gauge=gauge)
+            labels = ['lv', 'rv', 'p'] if self.U1 else ['lv', 'p', 'rv']
+            center = (len(self.H) - 1) if self.gauge.lower() == "left" else 0
 
-            if self.gauge.lower() == "left":
+            if self.nstates == 1:
+                self.e_tot = e_elec + shift
+                self.ground_state = MPS(mps_out, labels=labels, center=center)
+                self.states = [self.ground_state]
+            else:
+                self.e_tot = [e + shift for e in e_elec]
+                self.states = [MPS(s, labels=labels, center=center) for s in mps_out]
+                self.ground_state = self.states[0]
 
-                self.ground_state = MPS(ground_state, labels=labels,\
-                                        center=len(ground_state)-1)
-                    
-                self.ground_state.left_canonicalize()
-
-            elif self.gauge.lower() == "right":
-
-                self.ground_state = MPS(ground_state, labels=labels,
-                                        center=0)
-                self.ground_state.right_canonicalize()
-
-        else:
-            raise ValueError('Optimization algorithm {self.opt} does not exist. Use "1site" or "2site".')
+            for s in self.states:
+                if self.gauge.lower() == "left": 
+                    s.left_canonicalize()
+                else: 
+                    s.right_canonicalize()
 
         return self
-
     def expect(self, e_ops):
         """
         Compute expectation value of ground states

--- a/pyqed/mps/dmrg.py
+++ b/pyqed/mps/dmrg.py
@@ -25,7 +25,7 @@ class DMRG:
     def __init__(self, H, D, init_guess=None, nsweeps=50, opt='2site',\
                 symmetry=False, charge=None, spin = None,\
                 target_qn = None, sym_mgr = None, not_conv_err=True,
-                nstates=1, weights=None): # [FIX] Added nstates and weights
+                nstates=1, weights=None):
         """
         Parameters
         ----------

--- a/pyqed/mps/mps.py
+++ b/pyqed/mps/mps.py
@@ -34,7 +34,7 @@ from pyqed.mps.decompose import decompose, compress
 import logging
 logger = logging.getLogger(__name__)
 try:
-    from pyqed.mps.symmetry import BlockTensor, tensordot, solve_davidson, QN, SymmetryManager
+    from pyqed.mps.symmetry import BlockTensor, tensordot, solve_davidson, solve_davidson_block, QN, SymmetryManager
     SYMMETRY_AVAILABLE = True
 except ImportError:
     SYMMETRY_AVAILABLE = False
@@ -937,7 +937,7 @@ class MPS:
         - Moves orthogonality center to the last site (L-1).
         """
         if SYMMETRY_AVAILABLE and isinstance(self.Bs[0], BlockTensor):
-            self.Center = self.L - 1
+            self.center = self.L - 1
             return
         if self.Ss is None or len(self.Ss) != self.nbonds:
             self.Ss = [None] * self.nbonds
@@ -967,7 +967,7 @@ class MPS:
         B_last /= np.linalg.norm(B_last)
         self.Bs[self.L - 1] = B_last.transpose(perm_inv)
         # Update Center
-        self.Center = self.L - 1
+        self.center = self.L - 1
 
     def right_canonicalize(self):
         """
@@ -978,7 +978,7 @@ class MPS:
         - Moves orthogonality center to the first site (0).
         """
         if SYMMETRY_AVAILABLE and isinstance(self.Bs[0], BlockTensor):
-            self.Center = 0
+            self.center = 0
             return
         if self.Ss is None or len(self.Ss) != self.nbonds:
             self.Ss = [None] * self.nbonds
@@ -1009,7 +1009,7 @@ class MPS:
         B_first /= np.linalg.norm(B_first)
         self.Bs[0] = B_first.transpose(perm_inv)
         # Update Center
-        self.Center = 0
+        self.center = 0
 
     def left_to_vidal(self):
         pass
@@ -3536,7 +3536,22 @@ def sa_svd_symmetric(AA_list, weights, dir, m_max=None):
     V_t = BlockTensor(final_V, [bond_qns, AA_perm_0.qns[2], AA_perm_0.qns[3]], [-1, AA_perm_0.dirs[2], AA_perm_0.dirs[3]])
     return U_t, V_t, final_S, 0.0, sum(len(v) for v in kept.values())
 
-def optimize_two_sites(A, B, W1, W2, E, F, m, dir, U1=False, sym_mgr=None, nstates=1, weights=None):
+def compatible_blocktensor_structure(x, y):
+    if x.rank != y.rank:
+        return False
+    if x.dirs != y.dirs:
+        return False
+    if len(x.qns) != len(y.qns):
+        return False
+    for qx, qy in zip(x.qns, y.qns):
+        if qx != qy:
+            return False
+    for k, bx in x.data.items():
+        if k in y.data and bx.shape != y.data[k].shape:
+            return False
+    return True
+
+def optimize_two_sites(A, B, W1, W2, E, F, m, dir, U1=False, sym_mgr=None, nstates=1, weights=None, init_vecs = None):
     """
     two-site optimization of MPS A,B with respect to MPO W1,W2 and
     environment tensors E,F
@@ -3622,7 +3637,37 @@ def optimize_two_sites(A, B, W1, W2, E, F, m, dir, U1=False, sym_mgr=None, nstat
                 B_new = V
             return energy, A_new, B_new, trunc, m_kept
         else: # state average dmrg
-            energies, AA_new_list = solve_davidson(H_op, AA, n_eig=nstates, tol=1e-5)
+            guess_list = [AA]
+            if init_vecs is not None:
+                valid = [g for g in init_vecs if compatible_blocktensor_structure(g, AA)]
+                if len(valid) > 0:
+                    guess_list = valid[:nstates]
+
+            # Add tiny random companions if we need more than one state
+            # and no previous local state guesses are being passed in yet.
+            rng = np.random.default_rng(1234)
+            for _ in range(1, nstates):
+                data = {}
+                for k, blk in AA.data.items():
+                    noise = rng.standard_normal(blk.shape)
+                    if np.iscomplexobj(blk):
+                        noise = noise + 1j * rng.standard_normal(blk.shape)
+                    data[k] = noise.astype(blk.dtype, copy=False)
+                guess = BlockTensor(data, AA.qns[:], AA.dirs[:])
+
+                # Bias toward the current AA sector structure a bit
+                guess = AA * 1e-3 + guess
+                guess_list.append(guess)
+
+            energies, AA_new_list = solve_davidson_block(
+                H_op,
+                guess_list,
+                n_eig=nstates,
+                tol=1e-5,
+                max_iter=30,
+                max_subspace=max(8, 4 * nstates),
+            )
+
             U, V, S_dict, trunc, m_kept = sa_svd_symmetric(AA_new_list, weights, dir=dir, m_max=m)
             if dir == 'right':
                 A_new, B_new = U.transpose(0, 2, 1), multiply_S_V(S_dict, V)
@@ -3693,13 +3738,15 @@ def two_site_dmrg(mps, mpo, m, sweeps=50, conv=1e-6, U1=False, target_qn=None,\
     
     last_i = 0
     last_AA_list = None
-    
+    bond_guess_cache = {}
     for sweep in range(0, int(sweeps/2)):
         for i in range(0, len(MPS)-2):
             if nstates > 1:
+                init_vecs = bond_guess_cache.get(i, None)
                 Energy, MPS[i], MPS[i+1], trunc, states, last_AA_list = optimize_two_sites(
-                    MPS[i], MPS[i+1], MPO[i], MPO[i+1], E[-1], F[-1], m, 'right', U1, sym_mgr, nstates, weights)
+                    MPS[i], MPS[i+1], MPO[i], MPO[i+1], E[-1], F[-1], m, 'right', U1, sym_mgr, nstates, weights, init_vecs=last_AA_list)
                 E_ground_state = Energy[0]
+                bond_guess_cache[i] = last_AA_list
             else:
                 Energy, MPS[i], MPS[i+1], trunc, states = optimize_two_sites(
                     MPS[i], MPS[i+1], MPO[i], MPO[i+1], E[-1], F[-1], m, 'right', U1=U1, sym_mgr=sym_mgr)

--- a/pyqed/mps/mps.py
+++ b/pyqed/mps/mps.py
@@ -3408,8 +3408,135 @@ def inject_noise_symmetric(AA, sym_mgr, noise_val=1e-4):
                         AA.data[key] = noise.astype(dtype)
     return AA
 
+# Helper to contract Diagonal S into U
+# U is (L, P_L, Bond). S is (Bond, Bond).
+# We want U*S -> (L, P_L, Bond)
+def multiply_U_S(U_tensor, S_data):
+    # U: data[(qL, qP, qM)] -> shape (dL, dP, dM)
+    # S: data[qM] -> shape (dM, dM)
+    new_data = {}
+    for (qL, qP, qM), block in U_tensor.data.items():
+        if qM in S_data:
+            # Contract last index of U with S
+            # block: (dL, dP, dM). S: (dM, dM)
+            # Result: (dL, dP, dM)
+            new_block = np.tensordot(block, S_data[qM], axes=([2], [0]))
+            new_data[(qL, qP, qM)] = new_block
+    return BlockTensor(new_data, U_tensor.qns, U_tensor.dirs)
+# Helper to contract S into V
+# S is (Bond, Bond). V is (Bond, R, P_R).
+# We want S*V -> (Bond, R, P_R)
+def multiply_S_V(S_data, V_tensor):
+    new_data = {}
+    for (qM, qR, qP), block in V_tensor.data.items():
+        if qM in S_data:
+            # Contract S with first index of V
+            # S: (dM, dM). block: (dM, dR, dP)
+            # Result: (dM, dR, dP)
+            new_block = np.tensordot(S_data[qM], block, axes=([1], [0]))
+            new_data[(qM, qR, qP)] = new_block
+    return BlockTensor(new_data, V_tensor.qns, V_tensor.dirs)
 
-def optimize_two_sites(A, B, W1, W2, E, F, m, dir, U1=False, sym_mgr=None):
+def sa_svd_symmetric(AA_list, weights, dir, m_max=None):
+    """State-Averaged SVD for U(1) BlockTensors."""
+    AA_perm_0 = AA_list[0].transpose(0, 2, 1, 3)
+    blocks_by_q_mid = {}
+    row_map, col_map = {}, {}
+    M_dict = {k: {} for k in range(len(AA_list))}
+    
+    for k, AA in enumerate(AA_list):
+        AA_perm = AA.transpose(0, 2, 1, 3)
+        for qn_tuple, block in AA_perm.data.items():
+            q_L, q_phys_L, q_R, q_phys_R = qn_tuple
+            q_mid = q_L + q_phys_L
+            if q_mid not in blocks_by_q_mid:
+                blocks_by_q_mid[q_mid] = []
+                row_map[q_mid] = set()
+                col_map[q_mid] = set()
+            if k == 0:
+                blocks_by_q_mid[q_mid].append(qn_tuple)
+                row_map[q_mid].add((q_L, q_phys_L))
+                col_map[q_mid].add((q_R, q_phys_R))
+            M_dict[k].setdefault(q_mid, []).append((qn_tuple, block))
+            
+    sv_list = []
+    U_store, V_store, S_store = {}, {}, {}
+    
+    for q_mid in blocks_by_q_mid.keys():
+        rows, cols = sorted(row_map[q_mid]), sorted(col_map[q_mid])
+        r_starts, c_starts = {}, {}
+        r_dim = c_dim = 0
+        entries_0 = M_dict[0][q_mid]
+        
+        for r in rows:
+            for qn, blk in entries_0:
+                if (qn[0], qn[1]) == r:
+                    r_starts[r] = r_dim; r_dim += blk.shape[0] * blk.shape[1]; break
+        for c in cols:
+            for qn, blk in entries_0:
+                if (qn[2], qn[3]) == c:
+                    c_starts[c] = c_dim; c_dim += blk.shape[2] * blk.shape[3]; break
+                    
+        M_matrices = []
+        for k in range(len(AA_list)):
+            M = np.zeros((r_dim, c_dim), dtype=entries_0[0][1].dtype)
+            for qn, blk in M_dict[k][q_mid]:
+                r0, c0 = r_starts[(qn[0], qn[1])], c_starts[(qn[2], qn[3])]
+                M[r0:r0+blk.shape[0]*blk.shape[1], c0:c0+blk.shape[2]*blk.shape[3]] = blk.reshape(blk.shape[0]*blk.shape[1], blk.shape[2]*blk.shape[3])
+            M_matrices.append(M)
+            
+        if dir == 'right':
+            rho = np.zeros((r_dim, r_dim), dtype=M.dtype)
+            for k in range(len(AA_list)): rho += weights[k] * (M_matrices[k] @ M_matrices[k].conj().T)
+            S2, U = np.linalg.eigh(rho)
+            idx = np.argsort(S2)[::-1]; S2, U = S2[idx], U[:, idx]
+            S = np.sqrt(np.abs(S2))
+            S_inv = np.zeros_like(S); S_inv[S > 1e-12] = 1.0 / S[S > 1e-12]
+            Vt = np.diag(S_inv) @ U.conj().T @ M_matrices[0] # Project State 0 to propagate
+        else:
+            rho = np.zeros((c_dim, c_dim), dtype=M.dtype)
+            for k in range(len(AA_list)): rho += weights[k] * (M_matrices[k].conj().T @ M_matrices[k])
+            S2, V = np.linalg.eigh(rho)
+            idx = np.argsort(S2)[::-1]; S2, V = S2[idx], V[:, idx]
+            S = np.sqrt(np.abs(S2))
+            Vt = V.conj().T
+            S_inv = np.zeros_like(S); S_inv[S > 1e-12] = 1.0 / S[S > 1e-12]
+            U = M_matrices[0] @ V @ np.diag(S_inv) # Project State 0 to propagate
+            
+        S_store[q_mid] = S
+        for i, s in enumerate(S): sv_list.append((s, q_mid, i))
+        U_store[q_mid] = (U, rows, r_starts, entries_0)
+        V_store[q_mid] = (Vt, cols, c_starts, entries_0)
+        
+    sv_list.sort(reverse=True, key=lambda x: x[0])
+    if m_max is not None: sv_list = sv_list[:m_max]
+    kept = {}
+    for s, q_mid, i in sv_list: kept.setdefault(q_mid, []).append(i)
+        
+    final_U, final_V, final_S, bond_qns = {}, {}, {}, []
+    for q_mid, idxs in kept.items():
+        idxs = sorted(idxs)
+        U, rows, r_starts, entries_0 = U_store[q_mid]
+        Vt, cols, c_starts, entries_0 = V_store[q_mid]
+        final_S[q_mid] = np.diag(S_store[q_mid][idxs])
+        bond_qns.extend([q_mid] * len(idxs))
+        
+        for r in rows:
+            for qn, blk in entries_0:
+                if (qn[0], qn[1]) == r: d1, d2 = blk.shape[0], blk.shape[1]; break
+            r0 = r_starts[r]
+            final_U[(r[0], r[1], q_mid)] = U[r0:r0+d1*d2, idxs].reshape(d1, d2, len(idxs))
+        for c in cols:
+            for qn, blk in entries_0:
+                if (qn[2], qn[3]) == c: d3, d4 = blk.shape[2], blk.shape[3]; break
+            c0 = c_starts[c]
+            final_V[(q_mid, c[0], c[1])] = Vt[idxs, c0:c0+d3*d4].reshape(len(idxs), d3, d4)
+            
+    U_t = BlockTensor(final_U, [AA_perm_0.qns[0], AA_perm_0.qns[1], bond_qns], [AA_perm_0.dirs[0], AA_perm_0.dirs[1], 1])
+    V_t = BlockTensor(final_V, [bond_qns, AA_perm_0.qns[2], AA_perm_0.qns[3]], [-1, AA_perm_0.dirs[2], AA_perm_0.dirs[3]])
+    return U_t, V_t, final_S, 0.0, sum(len(v) for v in kept.values())
+
+def optimize_two_sites(A, B, W1, W2, E, F, m, dir, U1=False, sym_mgr=None, nstates=1, weights=None):
     """
     two-site optimization of MPS A,B with respect to MPO W1,W2 and
     environment tensors E,F
@@ -3448,7 +3575,8 @@ def optimize_two_sites(A, B, W1, W2, E, F, m, dir, U1=False, sym_mgr=None):
         DESCRIPTION.
 
     """
-
+    if weights is None: 
+        weights = [1.0/nstates] * nstates
     if U1:
         if not SYMMETRY_AVAILABLE:
             raise ImportError("Symmetry module not found. Cannot run U1=True.")
@@ -3467,58 +3595,40 @@ def optimize_two_sites(A, B, W1, W2, E, F, m, dir, U1=False, sym_mgr=None):
         H_op = HamiltonianMultiplyU1(E, [W1, W2], F)
         norm = AA.norm()
         AA = AA * (1.0/norm)
-        energy, AA_new = solve_davidson(H_op, AA, tol=1e-5)
-        # AA_new is (L, R, Phys_L, Phys_R)
-        # We need to return A(L, M, P_L) and B(M, R, P_R)
-        U, V, S_dict, trunc, m_kept = svd_symmetric(AA_new, m_max=m)
-        # U is (L, P_L, M).
-        # V is (M, R, P_R).
-        # We need to contract S_dict into either U or V depending on 'dir'. (left or right sweep)
 
-        # Helper to contract Diagonal S into U
-        # U is (L, P_L, Bond). S is (Bond, Bond).
-        # We want U*S -> (L, P_L, Bond)
-        def multiply_U_S(U_tensor, S_data):
-            # U: data[(qL, qP, qM)] -> shape (dL, dP, dM)
-            # S: data[qM] -> shape (dM, dM)
-            new_data = {}
-            for (qL, qP, qM), block in U_tensor.data.items():
-                if qM in S_data:
-                    # Contract last index of U with S
-                    # block: (dL, dP, dM). S: (dM, dM)
-                    # Result: (dL, dP, dM)
-                    new_block = np.tensordot(block, S_data[qM], axes=([2], [0]))
-                    new_data[(qL, qP, qM)] = new_block
-            return BlockTensor(new_data, U_tensor.qns, U_tensor.dirs)
-        # Helper to contract S into V
-        # S is (Bond, Bond). V is (Bond, R, P_R).
-        # We want S*V -> (Bond, R, P_R)
-        def multiply_S_V(S_data, V_tensor):
-            new_data = {}
-            for (qM, qR, qP), block in V_tensor.data.items():
-                if qM in S_data:
-                    # Contract S with first index of V
-                    # S: (dM, dM). block: (dM, dR, dP)
-                    # Result: (dM, dR, dP)
-                    new_block = np.tensordot(S_data[qM], block, axes=([1], [0]))
-                    new_data[(qM, qR, qP)] = new_block
-            return BlockTensor(new_data, V_tensor.qns, V_tensor.dirs)
-        if dir == 'right':  # Right Sweep: Center moves Right.
-            # A = U. B = S * V.
-            # U is (L, P_L, M). Transpose to standard MPS shape A(L, M, P_L)
-            A_new = U.transpose(0, 2, 1)
-            # Contract S into V, then V is already (M, R, P_R), which is standard B shape
-            B_new = multiply_S_V(S_dict, V)
-        else: # that is dir == 'left'
-            # Left Sweep: Center moves Left.
-            # A = U * S. B = V.
-            # Contract U * S first
-            A_US = multiply_U_S(U, S_dict)
-            # Transpose to standard MPS shape A(L, M, P_L)
-            A_new = A_US.transpose(0, 2, 1)
-            # B is just V
-            B_new = V
-        return energy, A_new, B_new, trunc, m_kept
+        if nstates == 1:
+            energy, AA_new = solve_davidson(H_op, AA, n_eig=1, tol=1e-5)
+            # AA_new is (L, R, Phys_L, Phys_R)
+            # We need to return A(L, M, P_L) and B(M, R, P_R)
+            U, V, S_dict, trunc, m_kept = svd_symmetric(AA_new, m_max=m)
+            # U is (L, P_L, M).
+            # V is (M, R, P_R).
+            # We need to contract S_dict into either U or V depending on 'dir'. (left or right sweep)
+
+            if dir == 'right':  # Right Sweep: Center moves Right.
+                # A = U. B = S * V.
+                # U is (L, P_L, M). Transpose to standard MPS shape A(L, M, P_L)
+                A_new = U.transpose(0, 2, 1)
+                # Contract S into V, then V is already (M, R, P_R), which is standard B shape
+                B_new = multiply_S_V(S_dict, V)
+            else: # that is dir == 'left'
+                # Left Sweep: Center moves Left.
+                # A = U * S. B = V.
+                # Contract U * S first
+                A_US = multiply_U_S(U, S_dict)
+                # Transpose to standard MPS shape A(L, M, P_L)
+                A_new = A_US.transpose(0, 2, 1)
+                # B is just V
+                B_new = V
+            return energy, A_new, B_new, trunc, m_kept
+        else: # state average dmrg
+            energies, AA_new_list = solve_davidson(H_op, AA, n_eig=nstates, tol=1e-5)
+            U, V, S_dict, trunc, m_kept = sa_svd_symmetric(AA_new_list, weights, dir=dir, m_max=m)
+            if dir == 'right':
+                A_new, B_new = U.transpose(0, 2, 1), multiply_S_V(S_dict, V)
+            else:
+                A_new, B_new = multiply_U_S(U, S_dict).transpose(0, 2, 1), V
+            return energies, A_new, B_new, trunc, m_kept, AA_new_list
     else: # Dense branch ( MPS index standardized to Left, Phys, Right)
         W = coarse_grain_MPO(W1,W2)
         # Returns (Left, Phys_A, Phys_B, Right)
@@ -3544,7 +3654,7 @@ def optimize_two_sites(A, B, W1, W2, E, F, m, dir, U1=False, sym_mgr=None):
         return E[0], A, B, trunc, m
 
 def two_site_dmrg(mps, mpo, m, sweeps=50, conv=1e-6, U1=False, target_qn=None,\
-                  not_conv_err=True, sym_mgr=None):
+                  not_conv_err=True, sym_mgr=None, nstates=1, weights=None):
     """
     Driver function to perform sweeps of 2-site DMRG
 
@@ -3566,6 +3676,9 @@ def two_site_dmrg(mps, mpo, m, sweeps=50, conv=1e-6, U1=False, target_qn=None,\
         DESCRIPTION.
 
     """
+    if weights is None: 
+        weights = [1.0/nstates] * nstates
+    weights = np.array(weights)
     MPS = mps 
     MPO = mpo 
     
@@ -3577,41 +3690,65 @@ def two_site_dmrg(mps, mpo, m, sweeps=50, conv=1e-6, U1=False, target_qn=None,\
     Eold = 0.0
     converged = False
     gauge = None
+    
+    last_i = 0
+    last_AA_list = None
+    
     for sweep in range(0, int(sweeps/2)):
         for i in range(0, len(MPS)-2):
-            Energy, MPS[i], MPS[i+1], trunc, states = optimize_two_sites(
-                MPS[i], MPS[i+1], MPO[i], MPO[i+1], E[-1], F[-1], m, 'right', U1=U1, sym_mgr=sym_mgr
-            )
-            logging.info("Sweep {:} Sites {:},{:}    Energy {:16.12f}    States {:4} Truncation {:16.12f}"
-                     .format(sweep*2,i,i+1, Energy, states, trunc))
+            if nstates > 1:
+                Energy, MPS[i], MPS[i+1], trunc, states, last_AA_list = optimize_two_sites(
+                    MPS[i], MPS[i+1], MPO[i], MPO[i+1], E[-1], F[-1], m, 'right', U1, sym_mgr, nstates, weights)
+                E_ground_state = Energy[0]
+            else:
+                Energy, MPS[i], MPS[i+1], trunc, states = optimize_two_sites(
+                    MPS[i], MPS[i+1], MPO[i], MPO[i+1], E[-1], F[-1], m, 'right', U1=U1, sym_mgr=sym_mgr)
+                E_ground_state = Energy
+            logging.info("Sweep {:} Sites {:},{:}    Energy {:16.12f}    States {:4} Truncation {:16.12f}".format(sweep*2,i,i+1, E_ground_state, states, trunc))
 
             E.append(contract_from_left(MPO[i], MPS[i], E[-1], MPS[i]))
             F.pop()
+            last_i = i
 
-        if abs(Energy - Eold) < conv:
-            print("DMRG Converged at sweep {}. \n Total energy = {}".format(sweep, Energy))
+        if nstates > 1:
+            print(Energy)
+            e_avg = np.sum(weights * Energy) 
+        else:
+            e_avg = Energy
+        if abs(e_avg - Eold) < conv:
+            print("DMRG Converged at sweep {}. \n average energy = {}".format(sweep, e_avg))
             converged = True
             gauge = "Left"
             break
         else:
-            Eold = Energy
+            Eold = e_avg
 
         for i in range(len(MPS)-2, 0, -1):
-            Energy, MPS[i], MPS[i+1], trunc, states = optimize_two_sites(
-                MPS[i], MPS[i+1], MPO[i], MPO[i+1], E[-1], F[-1], m, 'left', U1=U1, sym_mgr=sym_mgr
-            )
+            if nstates > 1:
+                Energy, MPS[i], MPS[i+1], trunc, states, last_AA_list = optimize_two_sites(
+                    MPS[i], MPS[i+1], MPO[i], MPO[i+1], E[-1], F[-1], m, 'left', U1=U1, sym_mgr=sym_mgr, nstates=nstates, weights=weights)
+                E_ground_state = Energy[0]
+            else:
+                Energy, MPS[i], MPS[i+1], trunc, states = optimize_two_sites(
+                    MPS[i], MPS[i+1], MPO[i], MPO[i+1], E[-1], F[-1], m, 'left', U1=U1, sym_mgr=sym_mgr)
+                
+                E_ground_state = Energy
             logging.info("Sweep {} Sites {},{}    Energy {:16.12f}    States {:4} Truncation {:16.12f}"
-                     .format(sweep*2+1, i, i+1, Energy, states, trunc))
+                     .format(sweep*2+1, i, i+1, E_ground_state, states, trunc))
             F.append(contract_from_right(MPO[i+1], MPS[i+1], F[-1], MPS[i+1]))
             E.pop()
-
-        if abs(Energy - Eold) < conv:
-            print("DMRG Converged at sweep {}. \n Total energy = {}".format(sweep, Energy))
+            last_i = i
+        if nstates > 1:
+            e_avg = np.sum(weights * Energy) 
+        else:
+            e_avg = Energy
+        if abs(e_avg - Eold) < conv:
+            print("DMRG Converged at sweep {}. \n average energy = {}".format(sweep, e_avg))
             converged = True
             gauge = "Right"
             break
         else:
-            Eold = Energy
+            Eold = e_avg
 
     if not_conv_err == True:
         if converged == False:
@@ -3622,7 +3759,49 @@ def two_site_dmrg(mps, mpo, m, sweeps=50, conv=1e-6, U1=False, target_qn=None,\
     if gauge == None:
         gauge = "Right"
 
-    return Energy, MPS, gauge, converged
+    center_i = len(MPS) // 2 - 1
+    
+    if gauge == "Left" and last_i > center_i: 
+        # Broke after Right Sweep. E and F are perfectly set up for a Left sweep start.
+        for i in range(len(MPS)-2, center_i - 1, -1):
+            if nstates > 1:
+                Energy, MPS[i], MPS[i+1], trunc, states, last_AA_list = optimize_two_sites(
+                    MPS[i], MPS[i+1], MPO[i], MPO[i+1], E[-1], F[-1], m, 'left', U1, sym_mgr, nstates, weights)
+            else:
+                Energy, MPS[i], MPS[i+1], trunc, states = optimize_two_sites(
+                    MPS[i], MPS[i+1], MPO[i], MPO[i+1], E[-1], F[-1], m, 'left', U1, sym_mgr)
+            if i > center_i: # Don't shift environments on the final stop
+                F.append(contract_from_right(MPO[i+1], MPS[i+1], F[-1], MPS[i+1]))
+                E.pop()
+            last_i = i
+
+    elif gauge == "Right" and last_i < center_i: 
+        # Broke after Left Sweep. E and F are perfectly set up for a Right sweep start.
+        for i in range(0, center_i + 1):
+            if nstates > 1:
+                Energy, MPS[i], MPS[i+1], trunc, states, last_AA_list = optimize_two_sites(
+                    MPS[i], MPS[i+1], MPO[i], MPO[i+1], E[-1], F[-1], m, 'right', U1, sym_mgr, nstates, weights)
+            else:
+                Energy, MPS[i], MPS[i+1], trunc, states = optimize_two_sites(
+                    MPS[i], MPS[i+1], MPO[i], MPO[i+1], E[-1], F[-1], m, 'right', U1, sym_mgr)
+            if i < center_i: # Don't shift environments on the final stop
+                E.append(contract_from_left(MPO[i], MPS[i], E[-1], MPS[i]))
+                F.pop()
+            last_i = i
+            
+    if nstates == 1:
+            return Energy, MPS, gauge, converged
+    else:
+        final_states = []
+        for k in range(nstates):
+            MPS_k = [B.copy() for B in MPS]
+            # Unspool the exact roots found at the last bond
+            U, V, S_dict, _, _ = svd_symmetric(last_AA_list[k], m_max=None)
+            A_US = multiply_U_S(U, S_dict)
+            MPS_k[last_i] = A_US.transpose(0, 2, 1)
+            MPS_k[last_i+1] = V
+            final_states.append(MPS_k)
+        return Energy, final_states, gauge, converged
 
 
 def expect_mps(bra, MPO, ket=None):

--- a/pyqed/mps/symmetry.py
+++ b/pyqed/mps/symmetry.py
@@ -2,7 +2,8 @@ import numpy as np
 import itertools
 from collections import defaultdict
 import time
-
+from scipy.sparse.linalg import LinearOperator, eigsh
+import copy
 
 class QN(tuple):
     """
@@ -221,8 +222,9 @@ def solve_davidson(H_linop, v0, n_eig=1, tol=1e-5, max_iter=20):
         
     v0 = v0 * (1.0 / norm_val)
     
-    V = [v0]; HV = []; T = np.zeros((0,0), dtype=complex)
-    curr_eig = 0.0; ritz_vec = v0
+    V = [v0]
+    HV = []
+    T = np.zeros((0,0), dtype=complex)
     
     for it in range(max_iter):
         v_new = V[-1]
@@ -237,21 +239,47 @@ def solve_davidson(H_linop, v0, n_eig=1, tol=1e-5, max_iter=20):
             T_new[m-1,i] = el.conjugate()
         T = T_new
         w, v = np.linalg.eigh(T)
-        curr_eig = w[0]
-        ritz_vec = V[0]*v[0,0]
-        ritz_H = HV[0]*v[0,0]
-        for i in range(1,m):
-            ritz_vec = ritz_vec + V[i]*v[i,0]
-            ritz_H = ritz_H + HV[i]*v[i,0]
-        resid = ritz_H - ritz_vec*curr_eig
-        if resid.norm() < tol: return curr_eig, ritz_vec
         
-        # Scale residual
-        q = resid * -10.0 
+        k_roots = min(n_eig, m)
+        ritz_vecs = []
+        ritz_Hs = []
+        for k in range(k_roots):
+            r_vec = V[0]*v[0,k]
+            r_H = HV[0]*v[0,k]
+            for i in range(1, m):
+                r_vec = r_vec + V[i]*v[i,k]
+                r_H = r_H + HV[i]*v[i,k]
+            ritz_vecs.append(r_vec)
+            ritz_Hs.append(r_H)
+            
+        resid_max = 0.0
+        for k in range(k_roots):
+            resid = ritz_Hs[k] - ritz_vecs[k] * w[k]
+            resid_max = max(resid_max, resid.norm())
+            
+        if resid_max < tol and k_roots == n_eig:
+            if n_eig == 1: return w[0], ritz_vecs[0]
+            else: return w[:k_roots], ritz_vecs
+            
+        # Preconditioner for next vector using sum of residuals
+        resid_sum = ritz_Hs[0] - ritz_vecs[0] * w[0]
+        for k in range(1, k_roots):
+            resid_sum = resid_sum + (ritz_Hs[k] - ritz_vecs[k] * w[k])
+            
+        q = resid_sum * -10.0 
         for vec in V:
             ov = vec.dot(q)
             q = q - vec*ov
         qn = q.norm()
-        if qn < 1e-9: return curr_eig, ritz_vec
+        if qn < 1e-9: 
+            if n_eig == 1: 
+                return w[0], ritz_vecs[0]
+            else: 
+                return w[:k_roots], ritz_vecs
         V.append(q * (1.0/qn))
-    return curr_eig, ritz_vec
+        
+    if n_eig == 1: 
+        return w[0], ritz_vecs[0]
+    else: 
+        return w[:k_roots], ritz_vecs
+

--- a/pyqed/mps/symmetry.py
+++ b/pyqed/mps/symmetry.py
@@ -258,8 +258,10 @@ def solve_davidson(H_linop, v0, n_eig=1, tol=1e-5, max_iter=20):
             resid_max = max(resid_max, resid.norm())
             
         if resid_max < tol and k_roots == n_eig:
-            if n_eig == 1: return w[0], ritz_vecs[0]
-            else: return w[:k_roots], ritz_vecs
+            if n_eig == 1: 
+                return w[0], ritz_vecs[0]
+            else: 
+                return w[:k_roots], ritz_vecs
             
         # Preconditioner for next vector using sum of residuals
         resid_sum = ritz_Hs[0] - ritz_vecs[0] * w[0]
@@ -283,3 +285,224 @@ def solve_davidson(H_linop, v0, n_eig=1, tol=1e-5, max_iter=20):
     else: 
         return w[:k_roots], ritz_vecs
 
+
+
+def _bt_random_like(v, seed=None):
+    """
+    Make a random BlockTensor with the same block structure as v.
+    """
+    rng = np.random.default_rng(seed)
+    data = {}
+    for k, blk in v.data.items():
+        arr = rng.standard_normal(blk.shape)
+        if np.iscomplexobj(blk):
+            arr = arr + 1j * rng.standard_normal(blk.shape)
+        data[k] = arr.astype(blk.dtype, copy=False)
+    return BlockTensor(data, v.qns[:], v.dirs[:])
+
+
+def _bt_orthonormalize(vec, basis, tol=1e-12, n_pass=2):
+    """
+    Modified Gram-Schmidt for BlockTensor vectors.
+    Returns normalized vector, or None if it becomes linearly dependent.
+    """
+    q = vec
+    for _ in range(n_pass):
+        for b in basis:
+            ov = b.dot(q)
+            q = q - b * ov
+    qn = q.norm()
+    if qn < tol:
+        return None
+    return q * (1.0 / qn)
+
+
+def solve_davidson_block(
+    H_linop,
+    v0_list,
+    n_eig=2,
+    tol=1e-5,
+    max_iter=30,
+    max_subspace=None,
+    lindep_tol=1e-12,
+    resid_add_tol=1e-10,
+    verbose=False,
+):
+    """
+    Block Davidson for BlockTensor-based linear operators.
+
+    Parameters
+    ----------
+    H_linop : object
+        Must provide matvec(v)
+    v0_list : BlockTensor or list[BlockTensor]
+        Initial guess vectors. For best performance, provide >= n_eig guesses.
+        If fewer are provided, the solver will auto-complete with random guesses
+        in the same sector/block structure as the first one.
+    n_eig : int
+        Number of lowest Ritz roots to target.
+    tol : float
+        Convergence threshold on max residual norm.
+    max_iter : int
+        Maximum number of outer iterations.
+    max_subspace : int or None
+        If exceeded, restart from current Ritz vectors.
+    lindep_tol : float
+        Threshold for removing linearly dependent trial vectors.
+    resid_add_tol : float
+        Threshold for accepting a correction vector.
+    verbose : bool
+        Print simple diagnostics.
+
+    Returns
+    -------
+    evals : ndarray shape (k,)
+    evecs : list[BlockTensor]
+    """
+    if not isinstance(v0_list, (list, tuple)):
+        v0_list = [v0_list]
+
+    if len(v0_list) == 0:
+        raise ValueError("solve_davidson_block needs at least one initial guess.")
+
+    proto = v0_list[0]
+
+    # If not enough guesses, augment with random vectors of same structure
+    guesses = [v.copy() for v in v0_list]
+    seed = 12345
+    while len(guesses) < n_eig:
+        guesses.append(_bt_random_like(proto, seed=seed))
+        seed += 1
+
+    # Build initial orthonormal basis
+    V = []
+    for v in guesses:
+        vn = v.norm()
+        if vn < lindep_tol:
+            continue
+        v = v * (1.0 / vn)
+        v = _bt_orthonormalize(v, V, tol=lindep_tol)
+        if v is not None:
+            V.append(v)
+
+    if len(V) == 0:
+        raise ValueError("All initial guesses are linearly dependent or zero.")
+
+    # Initial H|v>
+    HV = [H_linop.matvec(v) for v in V]
+
+    # Initial projected matrix T = V^† H V
+    m = len(V)
+    T = np.zeros((m, m), dtype=np.complex128)
+    for i in range(m):
+        for j in range(m):
+            T[i, j] = V[i].dot(HV[j])
+
+    evals = None
+    ritz_vecs = None
+
+    for it in range(max_iter):
+        # Hermitian projected problem
+        w, alpha = np.linalg.eigh(T)
+        idx = np.argsort(w.real)
+        w = w[idx]
+        alpha = alpha[:, idx]
+
+        k_roots = min(n_eig, len(w))
+        evals = w[:k_roots]
+
+        ritz_vecs = []
+        residuals = []
+        resid_norms = []
+
+        # Build Ritz vectors x_k = sum_i alpha_i^k V_i
+        # and Hx_k = sum_i alpha_i^k HV_i
+        for k in range(k_roots):
+            coeff = alpha[:, k]
+
+            xk = V[0] * coeff[0]
+            Hxk = HV[0] * coeff[0]
+            for i in range(1, len(V)):
+                xk = xk + V[i] * coeff[i]
+                Hxk = Hxk + HV[i] * coeff[i]
+
+            rk = Hxk - xk * w[k]
+
+            ritz_vecs.append(xk)
+            residuals.append(rk)
+            resid_norms.append(rk.norm())
+
+        max_resid = max(resid_norms) if resid_norms else 0.0
+
+        if verbose:
+            print(f"[Block-Davidson] iter={it:2d}  roots={k_roots}  "
+                  f"evals={np.real_if_close(evals)}  max_resid={max_resid:.3e}")
+
+        if k_roots == n_eig and max_resid < tol:
+            return evals, ritz_vecs
+
+        # Build one correction vector per unconverged root
+        new_vecs = []
+        trial_basis = V.copy()
+
+        for k in range(k_roots):
+            if resid_norms[k] < tol:
+                continue
+
+            # Identity preconditioner for now: q = r
+            q = residuals[k]
+
+            # Orthogonalize against current basis and accepted new vectors
+            q = _bt_orthonormalize(q, trial_basis, tol=resid_add_tol)
+            if q is None:
+                continue
+
+            new_vecs.append(q)
+            trial_basis.append(q)
+
+        # If no usable new direction was generated, return best current Ritz set
+        if len(new_vecs) == 0:
+            if verbose:
+                print("[Block-Davidson] No new directions generated; returning current Ritz vectors.")
+            return evals, ritz_vecs
+
+        # Simple restart if subspace too large
+        if max_subspace is not None and (len(V) + len(new_vecs) > max_subspace):
+            if verbose:
+                print(f"[Block-Davidson] Restarting subspace at dim={len(V)}")
+            V = []
+            for xk in ritz_vecs[:k_roots]:
+                xk = _bt_orthonormalize(xk, V, tol=lindep_tol)
+                if xk is not None:
+                    V.append(xk)
+
+            HV = [H_linop.matvec(v) for v in V]
+            m = len(V)
+            T = np.zeros((m, m), dtype=np.complex128)
+            for i in range(m):
+                for j in range(m):
+                    T[i, j] = V[i].dot(HV[j])
+            continue
+
+        # Append new directions
+        old_m = len(V)
+        for q in new_vecs:
+            V.append(q)
+            HV.append(H_linop.matvec(q))
+
+        new_m = len(V)
+
+        # Incrementally enlarge T
+        T_new = np.zeros((new_m, new_m), dtype=np.complex128)
+        T_new[:old_m, :old_m] = T
+
+        for j in range(old_m, new_m):
+            hj = HV[j]
+            for i in range(new_m):
+                val = V[i].dot(hj)
+                T_new[i, j] = val
+                T_new[j, i] = np.conjugate(val)
+
+        T = T_new
+
+    return evals, ritz_vecs

--- a/pyqed/qchem/dmrg/dmrg.py
+++ b/pyqed/qchem/dmrg/dmrg.py
@@ -162,25 +162,56 @@ def gen_cid_configs(nelec, nsites, mixing=0.1):
     return configs
 
 def gen_random_cisd_configs(nelec, nsites, n_states=10, mixing=0.1):
-    """Returns HF + Random Singles/Doubles"""
+    """Returns HF + Random Singles/Doubles that strictly conserve Sz."""
+    # Assuming gen_hf_config returns a list like [1, 1, 1, 1, 0, 0, ...]
     hf = gen_hf_config(nelec, nsites)
     configs = [(tuple(hf), 1.0)]
 
-    occ_idxs = [i for i, x in enumerate(hf) if x == 1]
-    vir_idxs = [i for i, x in enumerate(hf) if x == 0]
+    # Segregate occupied and virtual indices by Spin (Alpha=Even, Beta=Odd)
+    occ_alpha = [i for i, x in enumerate(hf) if x == 1 and i % 2 == 0]
+    occ_beta  = [i for i, x in enumerate(hf) if x == 1 and i % 2 == 1]
+    vir_alpha = [i for i, x in enumerate(hf) if x == 0 and i % 2 == 0]
+    vir_beta  = [i for i, x in enumerate(hf) if x == 0 and i % 2 == 1]
     
     for _ in range(n_states):
         new_cfg = list(hf)
-        if len(occ_idxs) >= 2 and len(vir_idxs) >= 2 and np.random.rand() > 0.5:
-            # Double
-            i, j = np.random.choice(occ_idxs, 2, replace=False)
-            a, b = np.random.choice(vir_idxs, 2, replace=False)
-            new_cfg[i]=0; new_cfg[j]=0; new_cfg[a]=1; new_cfg[b]=1
-        elif len(occ_idxs) >= 1 and len(vir_idxs) >= 1:
-            # Single
-            i = np.random.choice(occ_idxs)
-            a = np.random.choice(vir_idxs)
-            new_cfg[i]=0; new_cfg[a]=1
+        
+        # Determine physically valid excitations based on available electrons/holes
+        exc_types = []
+        if len(occ_alpha) >= 1 and len(vir_alpha) >= 1: exc_types.append('S_alpha')
+        if len(occ_beta) >= 1 and len(vir_beta) >= 1: exc_types.append('S_beta')
+        if len(occ_alpha) >= 2 and len(vir_alpha) >= 2: exc_types.append('D_aa')
+        if len(occ_beta) >= 2 and len(vir_beta) >= 2: exc_types.append('D_bb')
+        if len(occ_alpha) >= 1 and len(vir_alpha) >= 1 and len(occ_beta) >= 1 and len(vir_beta) >= 1: exc_types.append('D_ab')
+        
+        if not exc_types:
+            break # Active space too small for further excitations
+            
+        choice = np.random.choice(exc_types)
+        
+        if choice == 'S_alpha':
+            i = np.random.choice(occ_alpha); a = np.random.choice(vir_alpha)
+            new_cfg[i] = 0; new_cfg[a] = 1
+            
+        elif choice == 'S_beta':
+            i = np.random.choice(occ_beta); a = np.random.choice(vir_beta)
+            new_cfg[i] = 0; new_cfg[a] = 1
+            
+        elif choice == 'D_aa':
+            i, j = np.random.choice(occ_alpha, 2, replace=False)
+            a, b = np.random.choice(vir_alpha, 2, replace=False)
+            new_cfg[i] = 0; new_cfg[j] = 0; new_cfg[a] = 1; new_cfg[b] = 1
+            
+        elif choice == 'D_bb':
+            i, j = np.random.choice(occ_beta, 2, replace=False)
+            a, b = np.random.choice(vir_beta, 2, replace=False)
+            new_cfg[i] = 0; new_cfg[j] = 0; new_cfg[a] = 1; new_cfg[b] = 1
+            
+        elif choice == 'D_ab':
+            # The most important correlation for singlet states
+            i = np.random.choice(occ_alpha); a = np.random.choice(vir_alpha)
+            j = np.random.choice(occ_beta);  b = np.random.choice(vir_beta)
+            new_cfg[i] = 0; new_cfg[j] = 0; new_cfg[a] = 1; new_cfg[b] = 1
             
         configs.append((tuple(new_cfg), mixing))
         
@@ -747,7 +778,6 @@ class QCDMRG(CASCI):
                         ))
         if self.spin_purification:
             J = self.shift
-            print(f"  [Spin Penalty] Adding Exact S^2 Operator (J = {J})...")
             
             # On-site terms (p == q)
             for p in range(ncas):
@@ -824,17 +854,26 @@ class QCDMRG(CASCI):
         mpo = Mpo(model, algo="qr")
         mpo_dense = [w.transpose(0, 3, 1, 2) for w in mpo.matrices]
         
-        state = self.dmrg.ground_state
-        if hasattr(state.Bs[0], 'qns'):
-            dense_state = mps_lib.symmetric_to_dense(state)
-            psi_for_eval = dense_state.Bs
+        states_to_eval = self.dmrg.states 
+        if (hasattr(self.dmrg, 'states') and self.dmrg.states is not None):
+            states_to_eval = self.dmrg.states
         else:
-            psi_for_eval = state.Bs
+            states_to_eval = [self.dmrg.ground_state]
+        s2_vals = []
+        
+        for state in states_to_eval:
+            if hasattr(state.Bs[0], 'qns'):
+                dense_state = mps_lib.symmetric_to_dense(state)
+                psi_for_eval = dense_state.Bs
+            else:
+                psi_for_eval = state.Bs
+                
+            s2 = mps_lib.expect_mps(psi_for_eval, mpo_dense, psi_for_eval)
+            s2_vals.append(float(np.real(s2)))
             
-        s2_val = mps_lib.expect_mps(psi_for_eval, mpo_dense, psi_for_eval)
-        return float(np.real(s2_val))
+        return np.array(s2_vals) if self.nstates > 1 else s2_vals[0]
 
-    def run(self, nstates=1, symmetry_list=None, nsweeps=50, initial_guess=None, mo_coeff = None):
+    def run(self, nstates=1, weights=None, symmetry_list=None, nsweeps=50, initial_guess=None, mo_coeff = None, **kwargs):
         """
         Parameters
         ----------
@@ -842,6 +881,14 @@ class QCDMRG(CASCI):
             ['charge', 'sz'] or True/False.
         """
         self.nstates = nstates
+        if weights is None:
+            self.weights = np.ones(nstates) / nstates
+        else:
+            self.weights = np.array(weights)
+        if symmetry_list is not None:
+            self.saved_symmetry_list = symmetry_list
+        else:
+            symmetry_list = getattr(self, 'saved_symmetry_list', None)
         if initial_guess is not None:
             self.init_guess = initial_guess
         if mo_coeff is not None:
@@ -886,7 +933,7 @@ class QCDMRG(CASCI):
             self.sym_mgr = None
         t0 = time.time()
         print(f"  Starting Sweeps (D={self.D})...")
-        dmrg = DMRG(final_H, D=self.D, nsweeps=nsweeps, init_guess=mps0, symmetry=use_symmetry, target_qn=target_qn, sym_mgr=self.sym_mgr, not_conv_err=False)
+        dmrg = DMRG(final_H, D=self.D, nsweeps=nsweeps, init_guess=mps0, symmetry=use_symmetry, target_qn=target_qn, sym_mgr=self.sym_mgr, not_conv_err=False, nstates=self.nstates, weights=self.weights)
         dmrg.run()
         self.dmrg = dmrg
         # Report
@@ -896,9 +943,14 @@ class QCDMRG(CASCI):
             e_dmrg_total -= self.shift * s2_val
         self.e_tot = e_dmrg_total
         print(f"  RHF Energy:         {self.mf.e_tot:.8f} Ha")
-        print(f"  E(DMRG) =           {e_dmrg_total:.8f} Ha")
-        print(f"  Correlation Energy = {e_dmrg_total - self.mf.e_tot:.8f} Ha")
-        print(f"  <S^2> =             {s2_val:.6f}")
+        if self.nstates == 1:
+            print(f"  E(DMRG) =           {e_dmrg_total:.8f} Ha")
+            print(f"  Correlation Energy = {e_dmrg_total - self.mf.e_tot:.8f} Ha")
+            print(f"  <S^2> =             {s2_val:.6f}")
+        else:
+            for i in range(self.nstates):
+                print(f"  Root {i} E(DMRG) = {e_dmrg_total[i]:.8f} Ha")
+                print(f"  Root {i} E(DMRG) = {e_dmrg_total[i]:.8f} Ha, <S^2> = {s2_val[i]:.6f}")
         print(f"  Time:               {time.time()-t0:.2f} s")
         if use_symmetry:
             self.check_abelian_symmetry()

--- a/pyqed/qchem/dmrg/dmrgscf.py
+++ b/pyqed/qchem/dmrg/dmrgscf.py
@@ -7,6 +7,7 @@ DMRGSCF
 
 @author: Bing Gu (gubing at westlake dot edu dot cn)
 """
+# TODO: so since we are sharing CASSCF optimization code, currently after the DMRGSCF, final print get E(CASSCF) = xxxxxxx, it might be better if we fix that.
 from pyqed.qchem import QCDMRG, CASSCF
 from pyqed.qchem.mcscf.casscf import kernel, kernel_state_average
 import numpy as np
@@ -54,7 +55,7 @@ class DMRGSCF(QCDMRG):
         mc.ss = self.ss
         mc.shift = self.shift
 
-        mc.run(**kwargs)
+        mc.run(nstates=self.nstates, weights=self.weights, **kwargs)
 
         # matrix elements in CMOs
         h1e = mf.get_hcore_mo()
@@ -97,11 +98,11 @@ if __name__=='__main__':
 
     mf = mol.RHF().run()
 
-    mc = DMRGSCF(mf, ncas=2, nelecas=2, D=60, max_cycles=50)
+    mc = DMRGSCF(mf, ncas=6, nelecas=6, D=60, max_cycles=50)
 
     mc.fix_spin(ss=0, shift=0.2)
     mc.run(
-        nstates=1, # currently the nstates for dmrgscf is a dummy stuff, since we have not get excited states in the qcdmrg solver (or the dmrg solver)
+        nstates=2,
         symmetry_list=['charge', 'sz'], 
         initial_guess='cid'
     )

--- a/pyqed/qchem/mcscf/casscf.py
+++ b/pyqed/qchem/mcscf/casscf.py
@@ -69,7 +69,7 @@ class CASSCF(CASCI):
         # if self.spin_purification:
         #     mc.fix_spin(ss=self.ss, shift=self.shift)
 
-        mc.run(nstates)
+        mc.run(nstates, method='ci')
 
 
         # matrix elements in CMOs
@@ -369,14 +369,14 @@ if __name__=='__main__':
     from pyqed import Molecule
     # from pyqed.qchem.mcscf.direct_ci import CASCI
 
-    mol = Molecule(atom='Li 0 0 0; H 0 0 1.4', unit='b', basis='6311g')
+    mol = Molecule(atom='Li 0 0 0; F 0 0 1.4', unit='b', basis='6311g')
     mol.build(driver='pyscf')
 
     mf = mol.RHF().run()
 
-    mc = CASSCF(mf, ncas=2, nelecas=2, max_cycles=50)
+    mc = CASSCF(mf, ncas=6, nelecas=6, max_cycles=50)
 
-    nstates = 1
+    nstates = 2
     mc.state_average(weights = np.ones(nstates)/nstates)
     mc.fix_spin(ss=0, shift=0.2)
     mc.run()


### PR DESCRIPTION
major change:
-add primitive version of sa-dmrgscf
-fix the Davidson with proper space expansion for nstate > 1 case.
-example of sa-dmrgscf added in examples/qchem/dmrgscf

minor change:
-actually major trunk of code block change in mps.py is only rearrangement of the helper function. (move the helpers inside previous optimize_two_sites to outside)
-cid initial guess for the qcdmrg is fixed to provide correct quantum number. (other initial guess type might need refinement later on)

Issues:
-Observation is that dmrg convergence using state average energy is not that good. since the excited state energy is not the main optimization goal and would drift during the dmrg run. (maybe should change the convergence judgement for nstate >1 case, ground state usually converge better and excited state is more like fluctuating around instead of monotonically decrease)
-primitive stage test showed that the E(DMRG) ground state would be noticably lower if we are optimizing using nstate = 1.