### PR TITLE
add e_history in scf driver for both casscf and dmrgscf

### DIFF
--- a/examples/qchem/dmrgscf.py
+++ b/examples/qchem/dmrgscf.py
@@ -6,7 +6,7 @@ mol.build(driver='pyscf')
 
 mf = mol.RHF().run()
 
-mc = DMRGSCF(mf, ncas=4, nelecas=4, D=60, max_cycles=50)
+mc = DMRGSCF(mf, ncas=2, nelecas=2, D=60, max_cycles=50)
 
 mc.fix_spin(ss=0, shift=0.2)
 mc.run(
@@ -14,3 +14,9 @@ mc.run(
     symmetry_list=['charge', 'sz'], 
     initial_guess='cid'
 )
+
+# energy logs for you to use
+print(mc.e_tot[0]) #ground state energy
+print(mc.e_tot[1]) #fitst excited state
+print([list(h) for h in mc.e_history]) #whole energy log in list
+print(mc.e_history) #whole energy log in array

--- a/pyqed/qchem/dmrg/dmrgscf.py
+++ b/pyqed/qchem/dmrg/dmrgscf.py
@@ -80,6 +80,7 @@ class DMRGSCF(QCDMRG):
         self.mo_coeff = C
         self.e_tot = mc.e_tot
         self.ci = mc.ci
+        self.e_history = getattr(mc, 'e_history', [self.e_tot])
 
         return self
 

--- a/pyqed/qchem/mcscf/casscf.py
+++ b/pyqed/qchem/mcscf/casscf.py
@@ -34,6 +34,7 @@ class CASSCF(CASCI):
 
         self.weights = None
         self.nstates = 1
+        self.e_history = []
 
 
     def run(self, nstates= None, weights = None):

--- a/pyqed/qchem/mcscf/casscf.py
+++ b/pyqed/qchem/mcscf/casscf.py
@@ -230,7 +230,8 @@ def kernel_state_average(mc, weights, U0, nelecas, ncas, C0, h1e, eri,
         with_core = False
 
     nstates = mc.nstates
-
+    mc.e_history = [mc.e_tot]
+    
     dm1 = 0
     dm2 = 0
     for n in range(nstates):
@@ -250,6 +251,8 @@ def kernel_state_average(mc, weights, U0, nelecas, ncas, C0, h1e, eri,
         mo_coeff = C0 @ U
 
         mc.run(nstates, mo_coeff=mo_coeff, **kwargs)
+
+        mc.e_history.append(mc.e_tot)
 
         eAve = sum(weights * mc.e_tot)
 


### PR DESCRIPTION
add self.e_history in casscf.py could used to extract energy log in both casscf and dmrgscf run for better energy convergence comparison during the scf runs