### PR TITLE
Add canonical metadata to documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -94,6 +94,13 @@ autodoc_mock_imports = [
 #
 html_theme = 'sphinx_rtd_theme'
 
+# Consolidate Read the Docs aliases and historical versions around the public
+# documentation domain. Sphinx emits a per-page canonical link from this base.
+html_baseurl = os.environ.get(
+    'READTHEDOCS_CANONICAL_URL',
+    'https://docs.pyqed.org/en/latest/',
+)
+
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,3 +1,6 @@
+.. meta::
+   :description: Official PyQED documentation for quantum chemistry, nonadiabatic dynamics, open quantum systems, spectroscopy, and tensor-network methods.
+
 PyQED documentation
 ===================
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -1,3 +1,6 @@
+.. meta::
+   :description: Install PyQED and run a native H2 restricted Hartree--Fock calculation from molecular geometry to a converged energy.
+
 Five-minute quickstart
 ======================
 


### PR DESCRIPTION
## Summary

- configure Sphinx canonical links from the Read the Docs canonical URL, with the public docs domain as a local fallback
- add focused meta descriptions to the documentation homepage and quickstart
- consolidate duplicate Read the Docs version URLs for search engines once the custom domain is marked canonical

## Validation

- strict Sphinx HTML build with warnings treated as errors
- generated homepage and quickstart both contain canonical links
- generated homepage and quickstart both contain page-specific meta descriptions