### PR TITLE
Recover core modules and add citation metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,22 @@ env:
   MPLBACKEND: Agg
 
 jobs:
+  hygiene:
+    name: Repository hygiene
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+      - name: Reject unresolved merge markers
+        run: |
+          if git grep -nE '^(<<<<<<< |>>>>>>> )' -- '*.py' '*.pyx' '*.rst' '*.md' '*.toml' '*.yml' '*.yaml'; then
+            echo "Unresolved merge-conflict markers found."
+            exit 1
+          fi
+
   core:
     name: Core / Python ${{ matrix.python-version }}
+    needs: hygiene
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -43,6 +57,7 @@ jobs:
 
   native-extensions:
     name: Optional native extensions
+    needs: hygiene
     runs-on: ubuntu-latest
     env:
       PYQED_BUILD_EXTENSIONS: "1"
@@ -64,6 +79,7 @@ jobs:
 
   heom-extra:
     name: HEOM optional dependencies
+    needs: hygiene
     runs-on: ubuntu-latest
 
     steps:
@@ -80,6 +96,7 @@ jobs:
 
   distribution:
     name: Wheel and source distribution
+    needs: hygiene
     runs-on: ubuntu-latest
 
     steps:
@@ -99,21 +116,22 @@ jobs:
         run: |
           python -m venv /tmp/pyqed-wheel
           /tmp/pyqed-wheel/bin/python -m pip install --upgrade pip
-          /tmp/pyqed-wheel/bin/python -m pip install dist/pyqed-0.2.0-py3-none-any.whl
+          /tmp/pyqed-wheel/bin/python -m pip install dist/*.whl
           cd /tmp
           /tmp/pyqed-wheel/bin/python "$GITHUB_WORKSPACE/examples/quickstart.py"
-          /tmp/pyqed-wheel/bin/python -c 'from importlib.metadata import version; from importlib.util import find_spec; from pathlib import Path; import pyqed; from pyqed.gw import BSE, GW, TDA; from pyqed.namd import TDDFTDriver; from pyqed.qchem import MP2, Molecule; from pyqed.qchem.basis import _basis_path; from pyqed.qchem.dft import RKS; names=("pyqed.HEOM", "pyqed.HEOM.deom", "pyqed.floquet", "pyqed.gw", "pyqed.md", "pyqed.ml", "pyqed.namd", "pyqed.narg", "pyqed.mps.nonabelian", "pyqed.qchem.dft", "pyqed.qchem.mp"); assert pyqed.__version__ == version("pyqed") == "0.2.0"; assert Path(_basis_path("sto-3g")).is_file(); assert all(find_spec(name) is not None for name in names); assert all(item is not None for item in (BSE, GW, TDA, MP2, Molecule, RKS, TDDFTDriver))'
+          /tmp/pyqed-wheel/bin/python -c 'from importlib.metadata import version; from importlib.util import find_spec; from pathlib import Path; import pyqed; from pyqed.gw import BSE, GW, TDA; from pyqed.namd import TDDFTDriver; from pyqed.qchem import MP2, Molecule; from pyqed.qchem.basis import _basis_path; from pyqed.qchem.dft import RKS; names=("pyqed.HEOM", "pyqed.HEOM.deom", "pyqed.floquet", "pyqed.gw", "pyqed.md", "pyqed.ml", "pyqed.namd", "pyqed.narg", "pyqed.mps.nonabelian", "pyqed.qchem.dft", "pyqed.qchem.mp"); assert pyqed.__version__ == version("pyqed"); assert Path(_basis_path("sto-3g")).is_file(); assert all(find_spec(name) is not None for name in names); assert all(item is not None for item in (BSE, GW, TDA, MP2, Molecule, RKS, TDDFTDriver))'
           /tmp/pyqed-wheel/bin/python -m compileall -q /tmp/pyqed-wheel/lib/python3.13/site-packages/pyqed
       - name: Install and test the source distribution in isolation
         run: |
           python -m venv /tmp/pyqed-sdist
           /tmp/pyqed-sdist/bin/python -m pip install --upgrade pip
-          /tmp/pyqed-sdist/bin/python -m pip install dist/pyqed-0.2.0.tar.gz
+          /tmp/pyqed-sdist/bin/python -m pip install dist/*.tar.gz
           cd /tmp
           /tmp/pyqed-sdist/bin/python "$GITHUB_WORKSPACE/examples/quickstart.py"
 
   docs:
     name: Documentation
+    needs: hygiene
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+      - name: Reject unresolved merge markers
+        run: |
+          if git grep -nE '^(<<<<<<< |>>>>>>> )' -- '*.py' '*.pyx' '*.rst' '*.md' '*.toml' '*.yml' '*.yaml'; then
+            echo "Unresolved merge-conflict markers found."
+            exit 1
+          fi
       - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
@@ -69,7 +75,7 @@ jobs:
         run: |
           python -m venv /tmp/pyqed-release
           /tmp/pyqed-release/bin/python -m pip install --upgrade pip
-          /tmp/pyqed-release/bin/python -m pip install dist/pyqed-0.2.0-py3-none-any.whl
+          /tmp/pyqed-release/bin/python -m pip install dist/*.whl
           cd /tmp
           /tmp/pyqed-release/bin/python "$GITHUB_WORKSPACE/examples/quickstart.py"
           /tmp/pyqed-release/bin/python -c 'from importlib.metadata import version; from importlib.util import find_spec; import pyqed; from pyqed.gw import BSE, GW, TDA; from pyqed.namd import TDDFTDriver; from pyqed.qchem import MP2, Molecule; from pyqed.qchem.dft import RKS; names=("pyqed.HEOM", "pyqed.HEOM.deom", "pyqed.floquet", "pyqed.gw", "pyqed.md", "pyqed.ml", "pyqed.namd", "pyqed.narg", "pyqed.mps.nonabelian", "pyqed.qchem.dft", "pyqed.qchem.mp"); assert pyqed.__version__ == version("pyqed"); assert all(find_spec(name) is not None for name in names); assert all(item is not None for item in (BSE, GW, TDA, MP2, Molecule, RKS, TDDFTDriver))'

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,10 @@ pyqed/FCIDUMP
 pyqed/qchem/dvr/rhf-Bing的Mac Studio.py
 venv/
 .eggs/
+.tmp_*
+*-gugroup*
+*-Bing*MacBook Pro*
+*-Bing*Mac Studio*
 
 MacBook_local_data
 local_data

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,8 @@
 cff-version: 1.2.0
 message: >-
-  If you use PyQED, please cite the exact software release or Git commit and
-  the method-specific references for the algorithms used.
+  If you use PyQED, please cite the exact software release or Git commit, the
+  preferred project paper below, and the method-specific references for the
+  algorithms used.
 title: PyQED
 type: software
 version: 0.2.0
@@ -11,6 +12,20 @@ authors:
     given-names: Bing
   - family-names: Chen
     given-names: Zihao
+preferred-citation:
+  type: article
+  title: "PyQED: A Python Framework for Ab Initio Geometric Quantum Dynamics"
+  authors:
+    - family-names: Xie
+      given-names: Yujuan
+    - family-names: Zhu
+      given-names: Xiaotong
+    - family-names: Gu
+      given-names: Bing
+  journal: "Chinese Journal of Chemical Physics"
+  year: 2026
+  doi: "10.1063/1674-0068/cjcp2510161"
+  url: "https://doi.org/10.1063/1674-0068/cjcp2510161"
 repository-code: https://github.com/binggu56/pyqed
 url: https://pyqed.org
 license: MIT

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,8 +10,6 @@ date-released: 2026-07-11
 authors:
   - family-names: Gu
     given-names: Bing
-  - family-names: Chen
-    given-names: Zihao
 preferred-citation:
   type: article
   title: "PyQED: A Python Framework for Ab Initio Geometric Quantum Dynamics"
@@ -28,4 +26,9 @@ preferred-citation:
   url: "https://doi.org/10.1063/1674-0068/cjcp2510161"
 repository-code: https://github.com/binggu56/pyqed
 url: https://pyqed.org
+doi: "10.5281/zenodo.21316544"
+identifiers:
+  - type: doi
+    value: "10.5281/zenodo.21316543"
+    description: "PyQED software archive (all versions)"
 license: MIT

--- a/README.rst
+++ b/README.rst
@@ -111,16 +111,22 @@ Citing PyQED
 ------------
 
 Use the metadata in ``CITATION.cff`` and record the exact PyQED release or Git
-commit used.  Also cite the project paper:
+commit used.  The archived software has two DOI forms:
+
+* all PyQED versions: https://doi.org/10.5281/zenodo.21316543;
+* exact v0.2.0 archive: https://doi.org/10.5281/zenodo.21316544.
+
+Use the version-specific DOI when citing v0.2.0, and use the all-versions DOI
+when you want a citation that resolves to the latest archived release.  Also
+cite the project paper:
 
   Yujuan Xie, Xiaotong Zhu, and Bing Gu, “PyQED: A Python Framework for
   *Ab Initio* Geometric Quantum Dynamics,” *Chinese Journal of Chemical
   Physics* (2026), https://doi.org/10.1063/1674-0068/cjcp2510161.
 
-The article DOI is distinct from any present or future software-archive DOI.
-See the `citation guide
-<https://docs.pyqed.org/en/latest/citing.html>`_ for method-citation and
-reproducibility guidance.
+The article DOI is distinct from both software-archive DOIs.  See the
+`citation guide <https://docs.pyqed.org/en/latest/citing.html>`_ for
+method-citation and reproducibility guidance.
 
 License
 -------

--- a/README.rst
+++ b/README.rst
@@ -111,10 +111,16 @@ Citing PyQED
 ------------
 
 Use the metadata in ``CITATION.cff`` and record the exact PyQED release or Git
-commit used.  No project DOI is asserted until one appears in an archived
-release.  See the `citation guide
-<https://docs.pyqed.org/en/latest/citing.html>`_ for a reproducibility
-checklist.
+commit used.  Also cite the project paper:
+
+  Yujuan Xie, Xiaotong Zhu, and Bing Gu, “PyQED: A Python Framework for
+  *Ab Initio* Geometric Quantum Dynamics,” *Chinese Journal of Chemical
+  Physics* (2026), https://doi.org/10.1063/1674-0068/cjcp2510161.
+
+The article DOI is distinct from any present or future software-archive DOI.
+See the `citation guide
+<https://docs.pyqed.org/en/latest/citing.html>`_ for method-citation and
+reproducibility guidance.
 
 License
 -------

--- a/docs/_static/analytics.js
+++ b/docs/_static/analytics.js
@@ -1,0 +1,14 @@
+(() => {
+  const endpoint = "https://pyqed.org/api/analytics";
+  const event = "docs_pageview";
+  const payload = new Blob([event], { type: "text/plain;charset=UTF-8" });
+
+  if (navigator.sendBeacon?.(endpoint, payload)) return;
+
+  void fetch(endpoint, {
+    method: "POST",
+    body: event,
+    headers: { "Content-Type": "text/plain;charset=UTF-8" },
+    keepalive: true,
+  });
+})();

--- a/docs/source/citing.rst
+++ b/docs/source/citing.rst
@@ -17,9 +17,20 @@ control can render that metadata.  A reproducible citation should include:
 * the repository URL, https://github.com/binggu56/pyqed; and
 * the access or release year required by the target citation style.
 
-No project DOI is asserted in the repository at present.  If a future release
-is deposited in an archive, use the DOI shown by that specific archived
-release; do not infer or reuse a placeholder DOI.
+Project paper
+-------------
+
+In addition to the exact software release or commit, cite the PyQED project
+paper:
+
+  Yujuan Xie, Xiaotong Zhu, and Bing Gu, “PyQED: A Python Framework for
+  *Ab Initio* Geometric Quantum Dynamics,” *Chinese Journal of Chemical
+  Physics* (2026), https://doi.org/10.1063/1674-0068/cjcp2510161.
+
+The DOI above identifies the journal article, not an archived software
+release.  No software DOI is asserted in the repository at present.  If a
+future release is deposited in an archive, use the DOI shown by that specific
+archived release; do not reuse the article DOI.
 
 Method citations
 ----------------

--- a/docs/source/citing.rst
+++ b/docs/source/citing.rst
@@ -17,6 +17,14 @@ control can render that metadata.  A reproducible citation should include:
 * the repository URL, https://github.com/binggu56/pyqed; and
 * the access or release year required by the target citation style.
 
+The Zenodo software archive provides:
+
+* an all-versions DOI, https://doi.org/10.5281/zenodo.21316543; and
+* an exact v0.2.0 DOI, https://doi.org/10.5281/zenodo.21316544.
+
+Use the version-specific DOI when citing v0.2.0.  Use the all-versions DOI for
+a general PyQED citation that should resolve to the latest archived release.
+
 Project paper
 -------------
 
@@ -28,9 +36,9 @@ paper:
   Physics* (2026), https://doi.org/10.1063/1674-0068/cjcp2510161.
 
 The DOI above identifies the journal article, not an archived software
-release.  No software DOI is asserted in the repository at present.  If a
-future release is deposited in an archive, use the DOI shown by that specific
-archived release; do not reuse the article DOI.
+release.  It is distinct from both Zenodo software DOIs.  For a reproducible
+software citation, use the DOI shown by the specific archived release; do not
+reuse the article DOI.
 
 Method citations
 ----------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -106,3 +106,4 @@ html_baseurl = os.environ.get(
 # so a file named "default.css" will overwrite the builtin "default.css".
 _static_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '_static'))
 html_static_path = ['../_static'] if os.path.isdir(_static_path) else []
+html_js_files = ['analytics.js'] if html_static_path else []

--- a/pyqed/integrate.py
+++ b/pyqed/integrate.py
@@ -1,0 +1,261 @@
+"""Small ODE integration helpers used across :mod:`pyqed`."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+from scipy import linalg as la
+from scipy.integrate import DOP853 as _ScipyDOP853
+from scipy.integrate import solve_ivp as _scipy_solve_ivp
+
+
+def normalize_method(method):
+    """Normalize common ODE method aliases to the names used internally."""
+    method_key = str(method).lower().replace("_", "-")
+    if method_key in ("adaptive", "dopri853"):
+        return "dop853"
+    if method_key in ("exp-krylov", "expm-krylov", "exponential-krylov"):
+        return "krylov"
+    return method_key
+
+
+def _validate_t_eval(t_eval):
+    t_eval = np.asarray(t_eval, dtype=np.float64)
+    if t_eval.ndim != 1 or t_eval.size == 0:
+        raise ValueError("t_eval must be a non-empty one-dimensional array")
+    if not np.all(np.isfinite(t_eval)):
+        raise ValueError("t_eval must contain only finite values")
+    if np.any(np.diff(t_eval) <= 0.0):
+        raise ValueError("t_eval must be strictly increasing")
+    return t_eval
+
+
+def dop853(rhs, y0, t_eval, rtol=1.0e-8, atol=1.0e-10,
+           observer=None, save=True, **options):
+    """Integrate with adaptive DOP853 and stream values onto ``t_eval``.
+
+    ``save=False`` retains only the final state and optional ``observer``
+    values.  This is the memory-efficient generic path for Python right-hand
+    sides; compiled solvers can implement the same result contract internally.
+    """
+    t_eval = _validate_t_eval(t_eval)
+    initial = np.asarray(y0)
+    dtype = np.complex128 if np.iscomplexobj(initial) else np.float64
+    y = np.ascontiguousarray(initial, dtype=dtype).reshape(-1)
+    if y.size == 0:
+        raise ValueError("y0 must contain at least one value")
+
+    states = [y.copy()] if save else None
+    observations = [observer(t_eval[0], y)] if observer is not None else None
+    if t_eval.size == 1:
+        return SimpleNamespace(
+            success=True,
+            message="success",
+            nfev=0,
+            n_steps=0,
+            t=t_eval.copy(),
+            y=np.asarray(states).T if save else None,
+            y_final=y.copy(),
+            observations=observations,
+        )
+
+    solver = _ScipyDOP853(
+        rhs,
+        float(t_eval[0]),
+        y,
+        float(t_eval[-1]),
+        rtol=rtol,
+        atol=atol,
+        **options,
+    )
+    output_index = 1
+    n_steps = 0
+
+    while solver.status == "running":
+        message = solver.step()
+        if solver.status == "failed":
+            return SimpleNamespace(
+                success=False,
+                message=message or "DOP853 failed",
+                nfev=solver.nfev,
+                n_steps=n_steps,
+                t=t_eval[:output_index].copy(),
+                y=np.asarray(states).T if save else None,
+                y_final=solver.y.copy(),
+                observations=observations,
+            )
+        n_steps += 1
+        tolerance = (
+            32.0 * np.finfo(float).eps * max(1.0, abs(float(solver.t)))
+        )
+        due_end = output_index
+        while due_end < t_eval.size and t_eval[due_end] <= solver.t + tolerance:
+            due_end += 1
+
+        dense_output = None
+        for index in range(output_index, due_end):
+            sample_t = t_eval[index]
+            if abs(sample_t - solver.t) <= tolerance:
+                sample = solver.y.copy()
+            else:
+                if dense_output is None:
+                    dense_output = solver.dense_output()
+                sample = np.asarray(dense_output(sample_t)).copy()
+            if save:
+                states.append(sample)
+            if observer is not None:
+                observations.append(observer(sample_t, sample))
+        output_index = due_end
+
+    if output_index != t_eval.size:
+        raise RuntimeError("DOP853 did not reach every requested output time")
+
+    return SimpleNamespace(
+        success=True,
+        message="success",
+        nfev=solver.nfev,
+        n_steps=n_steps,
+        t=t_eval.copy(),
+        y=np.asarray(states).T if save else None,
+        y_final=solver.y.copy(),
+        observations=observations,
+    )
+
+
+def solve_ivp(rhs, y0, t_eval, method="DOP853", rtol=1.0e-8,
+              atol=1.0e-10, observer=None, save=True, **options):
+    """Integrate ``dy/dt = rhs(t, y)`` on a requested output grid."""
+    t_eval = _validate_t_eval(t_eval)
+    method_key = normalize_method(method)
+    if method_key == "dop853":
+        return dop853(
+            rhs,
+            y0,
+            t_eval,
+            rtol=rtol,
+            atol=atol,
+            observer=observer,
+            save=save,
+            **options,
+        )
+
+    y0 = np.asarray(y0)
+    if t_eval.size == 1:
+        y = y0.reshape(-1)
+        return SimpleNamespace(
+            success=True,
+            message="success",
+            nfev=0,
+            t=t_eval.copy(),
+            y=y.reshape(-1, 1).copy() if save else None,
+            y_final=y.copy(),
+            observations=[observer(t_eval[0], y)] if observer is not None else None,
+        )
+
+    solution = _scipy_solve_ivp(
+        rhs,
+        (float(t_eval[0]), float(t_eval[-1])),
+        y0,
+        method=method,
+        t_eval=t_eval,
+        rtol=rtol,
+        atol=atol,
+        **options,
+    )
+    solution.y_final = solution.y[:, -1].copy()
+    solution.observations = (
+        [observer(t, state) for t, state in zip(solution.t, solution.y.T)]
+        if observer is not None
+        else None
+    )
+    if not save:
+        solution.y = None
+    return solution
+
+
+def expm_krylov(matvec, y, dt, krylov_dim=30, tol=1.0e-12):
+    """Approximate ``exp(dt * A) @ y`` by Arnoldi using only ``A @ y``."""
+    y = np.asarray(y, dtype=np.complex128)
+    beta = np.linalg.norm(y)
+    if beta == 0:
+        return y.copy()
+
+    size = y.size
+    mmax = min(int(krylov_dim), size)
+    if mmax < 1:
+        raise ValueError("krylov_dim must be at least 1")
+
+    basis = np.zeros((mmax + 1, size), dtype=np.complex128)
+    hessenberg = np.zeros((mmax + 1, mmax), dtype=np.complex128)
+    basis[0] = y / beta
+    used_dim = mmax
+
+    for col in range(mmax):
+        work = matvec(basis[col])
+        for row in range(col + 1):
+            hessenberg[row, col] = np.vdot(basis[row], work)
+            work -= hessenberg[row, col] * basis[row]
+        next_norm = np.linalg.norm(work)
+        hessenberg[col + 1, col] = next_norm
+        if next_norm <= tol:
+            used_dim = col + 1
+            break
+        if col + 1 < mmax:
+            basis[col + 1] = work / next_norm
+
+    projected = hessenberg[:used_dim, :used_dim]
+    e1 = np.zeros(used_dim, dtype=np.complex128)
+    e1[0] = 1.0
+    coeff = la.expm(dt * projected) @ e1
+    return beta * (coeff @ basis[:used_dim])
+
+
+def krylov(matvec, y0, t_eval, krylov_dim=30, tol=1.0e-12,
+           observer=None, save=True, progress=None):
+    """Integrate a time-independent linear ODE with Krylov exponential steps."""
+    t_eval = np.asarray(t_eval, dtype=np.float64)
+    if t_eval.ndim != 1 or t_eval.size == 0:
+        raise ValueError("t_eval must be a non-empty one-dimensional array")
+
+    y = np.ascontiguousarray(np.asarray(y0, dtype=np.complex128).reshape(-1))
+    states = [y.copy()] if save else None
+    observations = [observer(t_eval[0], y)] if observer is not None else None
+
+    nfev = 0
+    steps = range(t_eval.size - 1)
+    if progress is not None:
+        steps = progress(steps)
+
+    for i in steps:
+        dt = t_eval[i + 1] - t_eval[i]
+        y = expm_krylov(matvec, y, dt, krylov_dim=krylov_dim, tol=tol)
+        nfev += min(int(krylov_dim), y.size)
+        if save:
+            states.append(y.copy())
+        if observer is not None:
+            observations.append(observer(t_eval[i + 1], y))
+
+    if save:
+        y_series = np.asarray(states, dtype=np.complex128).T
+    else:
+        y_series = None
+
+    return SimpleNamespace(
+        success=True,
+        message="success",
+        nfev=nfev,
+        t=t_eval.copy(),
+        y=y_series,
+        y_final=y.copy(),
+        observations=observations,
+    )
+
+
+__all__ = [
+    "dop853",
+    "expm_krylov",
+    "krylov",
+    "normalize_method",
+    "solve_ivp",
+]

--- a/pyqed/qchem/__init__.py
+++ b/pyqed/qchem/__init__.py
@@ -169,6 +169,15 @@ except (ImportError, OSError):
     CASCI = None
 
 try:
+    from .tdcasci import TDCASCI, TDCASCITrajectory
+    from .tdcis import TDCIS, cis_determinant_basis
+except (ImportError, OSError):
+    TDCASCI = None
+    TDCASCITrajectory = None
+    TDCIS = None
+    cis_determinant_basis = None
+
+try:
     from . import nac
 except (ImportError, OSError):
     nac = None

--- a/pyqed/qchem/tdcasci.py
+++ b/pyqed/qchem/tdcasci.py
@@ -1,0 +1,477 @@
+"""Time-dependent CASCI propagation in a fixed active orbital basis."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from scipy.linalg import expm
+
+from pyqed.qchem.mcscf.casci import contract_with_tdm1
+
+
+def _axis_to_index(axis):
+    if isinstance(axis, str):
+        key = axis.lower()
+        if key == "x":
+            return 0
+        if key == "y":
+            return 1
+        if key == "z":
+            return 2
+        raise ValueError("axis must be one of 'x', 'y', or 'z'.")
+    return int(axis)
+
+
+def _field_vector(source, time):
+    if source is None:
+        return np.zeros(3)
+    value = source(time) if callable(source) else source
+    vec = np.asarray(value, dtype=float)
+    if vec.ndim == 0:
+        out = np.zeros(3)
+        out[0] = float(vec)
+        return out
+    vec = vec.reshape(-1)
+    if vec.size != 3:
+        raise ValueError("field must evaluate to a scalar or a length-3 vector.")
+    return vec
+
+
+def _window_values(name, size):
+    key = "none" if name is None else str(name).lower()
+    if key in {"none", "boxcar", "rect", "rectangular"}:
+        return np.ones(int(size))
+    if key in {"hann", "hanning"}:
+        return np.hanning(int(size))
+    raise ValueError("window must be None, 'none', or 'hann'.")
+
+
+@dataclass
+class TDCASCITrajectory:
+    """Stored fixed-orbital TD-CASCI trajectory."""
+
+    times: np.ndarray
+    ci: np.ndarray | None
+    state_coefficients: np.ndarray | None
+    populations: np.ndarray | None
+    autocorrelation: np.ndarray
+    energies: np.ndarray
+    active_energies: np.ndarray
+    dipoles: np.ndarray
+    fields: np.ndarray
+    norms: np.ndarray
+    basis: str
+
+    def dipole_spectrum(self, axis="z", window="hann", subtract_mean=True):
+        """Return angular frequencies and dipole power spectrum."""
+        idx = _axis_to_index(axis)
+        signal = np.asarray(self.dipoles[:, idx], dtype=float)
+        if subtract_mean:
+            signal = signal - np.mean(signal)
+        dt = float(self.times[1] - self.times[0]) if self.times.size > 1 else 1.0
+        win = _window_values(window, signal.size)
+        response = np.fft.rfft(signal * win)
+        omega = 2.0 * np.pi * np.fft.rfftfreq(signal.size, d=dt)
+        return omega, np.abs(response) ** 2
+
+    def autocorrelation_spectrum(self, window="hann"):
+        """Return angular frequencies and autocorrelation spectrum."""
+        signal = np.asarray(self.autocorrelation, dtype=complex)
+        dt = float(self.times[1] - self.times[0]) if self.times.size > 1 else 1.0
+        win = _window_values(window, signal.size)
+        response = np.fft.fft(signal * win)
+        omega = 2.0 * np.pi * np.fft.fftfreq(signal.size, d=dt)
+        order = np.argsort(omega)
+        return omega[order], np.abs(response[order])
+
+
+class TDCASCI:
+    """
+    Time-dependent CASCI propagation in a fixed active orbital basis.
+
+    The default determinant-basis Hamiltonian is
+
+        H(t) = H_CASCI - E(t) . mu + h1(t)
+
+    where ``h1(t)`` is an optional user-supplied one-body operator in the MO or
+    active-MO basis.  The scalar core energy is included in reported energies
+    but omitted from the propagated Hamiltonian because it is only a global
+    phase.
+    """
+
+    def __init__(self, casci, interaction_mo=None, field=None, h1_mo=None):
+        if getattr(casci, "ci", None) is None or getattr(casci, "binary", None) is None:
+            raise ValueError("Run CASCI before starting TD-CASCI.")
+        if not hasattr(casci, "ci_sigma"):
+            raise ValueError("TDCASCI requires a CASCI object with ci_sigma().")
+
+        self.casci = casci
+        self.field = field
+        self.interaction_mo = interaction_mo
+        self.h1_mo = h1_mo
+        self.ndet = int(casci.binary.shape[0])
+        self.e_core = float(getattr(casci, "e_core", 0.0))
+        self._h0 = None
+        self._interaction_mats = None
+        self._core_interaction = None
+        self._one_body_cache = {}
+
+        self.times = None
+        self.ci = None
+        self.state_coefficients = None
+        self.populations = None
+        self.autocorrelation = None
+        self.energies = None
+        self.active_energies = None
+        self.dipoles = None
+        self.fields = None
+        self.norms = None
+
+    def _ensure_slater_condon_cache(self):
+        if hasattr(self.casci, "ensure_slater_condon_cache"):
+            return self.casci.ensure_slater_condon_cache()
+        sc1 = getattr(self.casci, "SC1", None)
+        if sc1 is None:
+            raise ValueError("CASCI Slater-Condon one-body cache is unavailable.")
+        return sc1, getattr(self.casci, "SC2", None)
+
+    def hamiltonian_matrix(self):
+        """Dense active-space CASCI Hamiltonian excluding the scalar core."""
+        if self._h0 is not None:
+            return self._h0
+        eye = np.eye(self.ndet, dtype=complex)
+        h0 = np.column_stack([self.casci.ci_sigma(eye[:, j]) for j in range(self.ndet)])
+        self._h0 = 0.5 * (h0 + h0.conj().T)
+        return self._h0
+
+    def state_basis(self, nstates=None):
+        """Return computed CASCI eigenvectors as determinant-basis columns."""
+        states = tuple(np.asarray(c, dtype=complex).reshape(-1) for c in self.casci.ci)
+        if nstates is None:
+            nstates = len(states)
+        nstates = int(nstates)
+        if nstates < 1 or nstates > len(states):
+            raise ValueError(f"nstates must be between 1 and {len(states)}.")
+        return np.column_stack(states[:nstates])
+
+    def state_energies(self, nstates=None, active=True):
+        """Return available CASCI root energies."""
+        energies = np.asarray(self.casci.e_tot, dtype=float)
+        if nstates is not None:
+            energies = energies[: int(nstates)]
+        if active:
+            energies = energies - self.e_core
+        return energies
+
+    def _operator_active_blocks(self, op, *, ncomponents=None):
+        ncore = int(getattr(self.casci, "ncore", 0))
+        ncas = int(getattr(self.casci, "ncas"))
+        active = slice(ncore, ncore + ncas)
+
+        if isinstance(op, tuple):
+            op_a = np.asarray(op[0], dtype=complex)
+            op_b = np.asarray(op[1], dtype=complex)
+        else:
+            op_a = np.asarray(op, dtype=complex)
+            op_b = op_a
+
+        if op_a.ndim == 2:
+            op_a = op_a[None, :, :]
+            op_b = op_b[None, :, :]
+        if ncomponents is not None and op_a.shape[0] == 1 and int(ncomponents) > 1:
+            op_a = np.repeat(op_a, int(ncomponents), axis=0)
+            op_b = np.repeat(op_b, int(ncomponents), axis=0)
+        if ncomponents is not None and op_a.shape[0] != int(ncomponents):
+            raise ValueError(
+                f"operator must have {int(ncomponents)} component(s); got {op_a.shape[0]}."
+            )
+
+        if op_a.shape[1] == ncas and op_a.shape[2] == ncas:
+            active_a = op_a
+            active_b = op_b
+            core = np.zeros(op_a.shape[0], dtype=complex)
+        else:
+            active_a = op_a[:, active, active]
+            active_b = op_b[:, active, active]
+            if ncore > 0:
+                core = (
+                    np.trace(op_a[:, :ncore, :ncore], axis1=1, axis2=2)
+                    + np.trace(op_b[:, :ncore, :ncore], axis1=1, axis2=2)
+                )
+            else:
+                core = np.zeros(op_a.shape[0], dtype=complex)
+        return active_a, active_b, core
+
+    def _one_body_matrix_from_blocks(self, active_a, active_b):
+        active_a = np.asarray(active_a, dtype=complex)
+        active_b = np.asarray(active_b, dtype=complex)
+        if active_a.ndim == 2:
+            active_a = active_a[None, :, :]
+            active_b = active_b[None, :, :]
+        sc1, _ = self._ensure_slater_condon_cache()
+        eye = np.eye(self.ndet, dtype=complex)
+        mats = np.zeros((active_a.shape[0], self.ndet, self.ndet), dtype=complex)
+        for comp in range(active_a.shape[0]):
+            h1e = (active_a[comp], active_b[comp])
+            for ket in range(self.ndet):
+                ciket = eye[:, ket]
+                for bra in range(self.ndet):
+                    mats[comp, bra, ket] = contract_with_tdm1(
+                        eye[:, bra],
+                        ciket,
+                        self.casci.binary,
+                        sc1,
+                        h1e,
+                    )
+        return 0.5 * (mats + mats.conj().transpose(0, 2, 1))
+
+    def one_body_matrix(self, op, *, ncomponents=None):
+        """Dense determinant-space matrix for a one-body MO operator."""
+        active_a, active_b, _core = self._operator_active_blocks(
+            op,
+            ncomponents=ncomponents,
+        )
+        return self._one_body_matrix_from_blocks(active_a, active_b)
+
+    def _interaction_active_blocks(self):
+        if self.interaction_mo is None:
+            if not hasattr(self.casci, "_electric_dipole_mo"):
+                raise ValueError(
+                    "No interaction_mo was supplied and the CASCI object cannot build dipoles."
+                )
+            op = self.casci._electric_dipole_mo()
+        else:
+            op = self.interaction_mo
+        return self._operator_active_blocks(op, ncomponents=3)
+
+    def interaction_matrices(self):
+        """Dense determinant-space one-body interaction matrices."""
+        if self._interaction_mats is not None:
+            return self._interaction_mats
+        active_a, active_b, core = self._interaction_active_blocks()
+        self._interaction_mats = self._one_body_matrix_from_blocks(active_a, active_b)
+        self._core_interaction = np.asarray(core, dtype=complex)
+        return self._interaction_mats
+
+    def field_vector(self, time, field=None):
+        """Evaluate an external field as a length-3 vector."""
+        return _field_vector(self.field if field is None else field, time)
+
+    def one_body_hamiltonian_matrix(self, time, h1_mo=None):
+        """Optional user-supplied one-body Hamiltonian contribution."""
+        source = self.h1_mo if h1_mo is None else h1_mo
+        if source is None:
+            return np.zeros((self.ndet, self.ndet), dtype=complex)
+        time_dependent = callable(source)
+        op = source(time) if time_dependent else source
+        if not time_dependent:
+            key = ("static_h1", id(op))
+            cached = self._one_body_cache.get(key)
+            if cached is not None:
+                return cached
+        mat = self.one_body_matrix(op, ncomponents=1)[0]
+        if not time_dependent:
+            self._one_body_cache[key] = mat
+        return mat
+
+    def ci_vector(self, ci0=0, *, basis="determinant", nstates=None):
+        """Return a normalized complex CI vector in the requested propagation basis."""
+        basis_key = str(basis).lower()
+        if basis_key in {"det", "determinant", "determinants"}:
+            if np.isscalar(ci0):
+                c = np.asarray(self.casci.ci[int(ci0)], dtype=complex).copy()
+            else:
+                c = np.asarray(ci0, dtype=complex).reshape(-1).copy()
+            expected = self.ndet
+        elif basis_key in {"state", "states", "adiabatic", "eigenstate", "eigenstates"}:
+            b = self.state_basis(nstates=nstates)
+            if np.isscalar(ci0):
+                c = np.zeros(b.shape[1], dtype=complex)
+                c[int(ci0)] = 1.0
+            else:
+                arr = np.asarray(ci0, dtype=complex).reshape(-1)
+                c = b.conj().T @ arr if arr.shape[0] == self.ndet else arr.copy()
+            expected = b.shape[1]
+        else:
+            raise ValueError("basis must be 'determinant' or 'state'.")
+        if c.shape[0] != expected:
+            raise ValueError(f"CI vector length {c.shape[0]} does not match basis size {expected}.")
+        norm = np.linalg.norm(c)
+        if norm == 0.0:
+            raise ValueError("Initial CI vector has zero norm.")
+        return c / norm
+
+    def _basis_matrix(self, basis="determinant", nstates=None):
+        basis_key = str(basis).lower()
+        if basis_key in {"det", "determinant", "determinants"}:
+            return None, "determinant"
+        if basis_key in {"state", "states", "adiabatic", "eigenstate", "eigenstates"}:
+            return self.state_basis(nstates=nstates), "state"
+        raise ValueError("basis must be 'determinant' or 'state'.")
+
+    def _to_determinant_basis(self, c, basis_matrix):
+        c = np.asarray(c, dtype=complex)
+        return c if basis_matrix is None else basis_matrix @ c
+
+    def _project_operator(self, op, basis_matrix):
+        if basis_matrix is None:
+            return op
+        return basis_matrix.conj().T @ op @ basis_matrix
+
+    def effective_hamiltonian(self, time, field=None, h1_mo=None, *, basis="determinant", nstates=None):
+        """Instantaneous active Hamiltonian excluding scalar core terms."""
+        basis_matrix, _basis_key = self._basis_matrix(basis=basis, nstates=nstates)
+        h = self.hamiltonian_matrix().copy()
+        f = self.field_vector(time, field=field)
+        if np.any(f):
+            h = h - np.einsum("x,xij->ij", f, self.interaction_matrices(), optimize=True)
+        h = h + self.one_body_hamiltonian_matrix(time, h1_mo=h1_mo)
+        h = self._project_operator(h, basis_matrix)
+        return 0.5 * (h + h.conj().T)
+
+    def step(self, c, time, dt, field=None, h1_mo=None, *, basis="determinant", nstates=None):
+        """Propagate one midpoint unitary step."""
+        h_mid = self.effective_hamiltonian(
+            float(time) + 0.5 * float(dt),
+            field=field,
+            h1_mo=h1_mo,
+            basis=basis,
+            nstates=nstates,
+        )
+        return expm(-1j * float(dt) * h_mid) @ np.asarray(c, dtype=complex)
+
+    def kick(self, c, strength=1.0e-4, axis="x", *, basis="determinant", nstates=None):
+        """Apply an impulsive one-body interaction to the CI vector."""
+        idx = _axis_to_index(axis)
+        basis_matrix, _basis_key = self._basis_matrix(basis=basis, nstates=nstates)
+        op = self._project_operator(self.interaction_matrices()[idx], basis_matrix)
+        u = expm(-1j * float(strength) * op)
+        return u @ np.asarray(c, dtype=complex)
+
+    def active_energy(self, c, *, basis="determinant", nstates=None):
+        """Field-free active-space energy expectation excluding scalar core."""
+        basis_matrix, _basis_key = self._basis_matrix(basis=basis, nstates=nstates)
+        c_det = self._to_determinant_basis(c, basis_matrix)
+        return np.vdot(c_det, self.hamiltonian_matrix() @ c_det)
+
+    def energy(self, c, *, basis="determinant", nstates=None):
+        """Field-free total CASCI energy expectation including scalar core."""
+        basis_matrix, _basis_key = self._basis_matrix(basis=basis, nstates=nstates)
+        c_det = self._to_determinant_basis(c, basis_matrix)
+        return self.active_energy(c_det) + self.e_core * np.vdot(c_det, c_det)
+
+    def dipole_moment(self, c, *, basis="determinant", nstates=None):
+        """Electronic dipole expectation value for the propagated CI vector."""
+        basis_matrix, _basis_key = self._basis_matrix(basis=basis, nstates=nstates)
+        c_det = self._to_determinant_basis(c, basis_matrix)
+        mats = self.interaction_matrices()
+        value = np.einsum("i,xij,j->x", c_det.conj(), mats, c_det, optimize=True)
+        core = np.zeros(3, dtype=complex) if self._core_interaction is None else self._core_interaction
+        value = value + core * np.vdot(c_det, c_det)
+        return value.real
+
+    def state_coefficients_for_vector(self, c, *, basis="determinant", nstates=None):
+        """Project a propagated vector onto the computed CASCI eigenstate basis."""
+        basis_matrix, basis_key = self._basis_matrix(basis=basis, nstates=nstates)
+        if basis_key == "state":
+            return np.asarray(c, dtype=complex).copy()
+        states = self.state_basis(nstates=nstates)
+        return states.conj().T @ np.asarray(c, dtype=complex)
+
+    def state_populations(self, c, *, basis="determinant", nstates=None):
+        """Return populations in the computed CASCI eigenstate basis."""
+        coeff = self.state_coefficients_for_vector(c, basis=basis, nstates=nstates)
+        return np.abs(coeff) ** 2
+
+    def run(
+        self,
+        dt,
+        nsteps,
+        ci0=0,
+        field=None,
+        h1_mo=None,
+        t0=0.0,
+        kick=None,
+        basis="determinant",
+        nstates=None,
+        store_ci=True,
+        store_state_coefficients=True,
+    ):
+        """Propagate a CASCI wavefunction for ``nsteps`` time steps."""
+        basis_matrix, basis_key = self._basis_matrix(basis=basis, nstates=nstates)
+        c = self.ci_vector(ci0, basis=basis_key, nstates=nstates)
+        if kick is not None:
+            c = self.kick(c, basis=basis_key, nstates=nstates, **kick)
+        c0_det = self._to_determinant_basis(c, basis_matrix)
+
+        dt = float(dt)
+        times = float(t0) + dt * np.arange(int(nsteps) + 1, dtype=float)
+        ci = None
+        if store_ci:
+            ci = np.zeros((times.size, self.ndet), dtype=complex)
+        nstate_dim = self.state_basis(nstates=nstates).shape[1]
+        state_coefficients = None
+        populations = None
+        if store_state_coefficients:
+            state_coefficients = np.zeros((times.size, nstate_dim), dtype=complex)
+            populations = np.zeros((times.size, nstate_dim), dtype=float)
+        autocorrelation = np.zeros(times.size, dtype=complex)
+        active_energies = np.zeros(times.size, dtype=float)
+        energies = np.zeros(times.size, dtype=float)
+        dipoles = np.zeros((times.size, 3), dtype=float)
+        fields = np.zeros((times.size, 3), dtype=float)
+        norms = np.zeros(times.size, dtype=float)
+
+        for istep, time in enumerate(times):
+            c_det = self._to_determinant_basis(c, basis_matrix)
+            if store_ci:
+                ci[istep] = c_det
+            if store_state_coefficients:
+                coeff = self.state_coefficients_for_vector(
+                    c,
+                    basis=basis_key,
+                    nstates=nstates,
+                )
+                state_coefficients[istep] = coeff
+                populations[istep] = np.abs(coeff) ** 2
+            autocorrelation[istep] = np.vdot(c0_det, c_det)
+            active_energies[istep] = self.active_energy(c_det).real
+            energies[istep] = self.energy(c_det).real
+            dipoles[istep] = self.dipole_moment(c_det)
+            fields[istep] = self.field_vector(time, field=field)
+            norms[istep] = np.vdot(c_det, c_det).real
+            if istep < times.size - 1:
+                c = self.step(
+                    c,
+                    time,
+                    dt,
+                    field=field,
+                    h1_mo=h1_mo,
+                    basis=basis_key,
+                    nstates=nstates,
+                )
+
+        self.times = times
+        self.ci = ci
+        self.state_coefficients = state_coefficients
+        self.populations = populations
+        self.autocorrelation = autocorrelation
+        self.active_energies = active_energies
+        self.energies = energies
+        self.dipoles = dipoles
+        self.fields = fields
+        self.norms = norms
+        return TDCASCITrajectory(
+            times=times,
+            ci=ci,
+            state_coefficients=state_coefficients,
+            populations=populations,
+            autocorrelation=autocorrelation,
+            energies=energies,
+            active_energies=active_energies,
+            dipoles=dipoles,
+            fields=fields,
+            norms=norms,
+            basis=basis_key,
+        )

--- a/pyqed/qchem/tdcis.py
+++ b/pyqed/qchem/tdcis.py
@@ -1,0 +1,135 @@
+"""Time-dependent CIS propagation in a fixed orbital basis."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from pyqed.qchem.ci.fci import CI_H, SlaterCondon
+from pyqed.qchem.mcscf.casci import _slice_active_orbitals
+from pyqed.qchem.mcscf.direct_ci import CASCI as DirectCASCI
+from pyqed.qchem.tdcasci import TDCASCI
+
+
+def _spin_occupations_from_mf(mf):
+    mo_occ = np.asarray(mf.mo_occ)
+    if mo_occ.ndim == 1:
+        occ = mo_occ > 0
+        occ_a = occ.astype(np.int8)
+        occ_b = occ.astype(np.int8)
+    elif mo_occ.ndim == 2 and mo_occ.shape[0] == 2:
+        occ_a = (mo_occ[0] > 0).astype(np.int8)
+        occ_b = (mo_occ[1] > 0).astype(np.int8)
+    else:
+        raise ValueError(f"Unsupported mo_occ shape for TD-CIS: {mo_occ.shape}.")
+    if occ_a.shape != occ_b.shape:
+        raise ValueError("Alpha and beta occupation arrays must have the same length.")
+    return occ_a, occ_b
+
+
+def cis_determinant_basis(mf):
+    """Return determinant occupations for HF plus all spin-orbital singles."""
+    occ_a, occ_b = _spin_occupations_from_mf(mf)
+    ref = np.stack((occ_a, occ_b)).astype(np.int8, copy=True)
+    determinants = [ref]
+    seen = {ref.tobytes()}
+    for spin, occ in enumerate((occ_a, occ_b)):
+        occupied = np.flatnonzero(occ > 0)
+        virtual = np.flatnonzero(occ == 0)
+        for i in occupied:
+            for a in virtual:
+                det = ref.copy()
+                det[spin, i] = 0
+                det[spin, a] = 1
+                key = det.tobytes()
+                if key not in seen:
+                    seen.add(key)
+                    determinants.append(det)
+    return np.asarray(determinants, dtype=np.int8)
+
+
+class TDCIS(TDCASCI):
+    """
+    Time-dependent CIS propagation in the HF + singles determinant space.
+
+    ``TDCIS`` reuses the fixed-orbital ``TDCASCI`` propagation machinery after
+    restricting the determinant basis to the reference determinant and all
+    single spin-orbital excitations.
+    """
+
+    def __init__(
+        self,
+        mf,
+        nstates=None,
+        interaction_mo=None,
+        field=None,
+        h1_mo=None,
+        use_cholesky=None,
+        verbose=0,
+    ):
+        if getattr(mf, "mo_coeff", None) is None or getattr(mf, "mo_occ", None) is None:
+            raise ValueError("Run HF before starting TD-CIS.")
+
+        occ_a, occ_b = _spin_occupations_from_mf(mf)
+        nmo = int(occ_a.size)
+        na = int(np.count_nonzero(occ_a))
+        nb = int(np.count_nonzero(occ_b))
+        binary = cis_determinant_basis(mf)
+        if nstates is None:
+            nstates = min(int(binary.shape[0]), 10)
+        nstates = int(nstates)
+        if nstates < 1:
+            raise ValueError("nstates must be positive.")
+        nstates = min(nstates, int(binary.shape[0]))
+
+        solver = DirectCASCI(
+            mf,
+            ncas=nmo,
+            nelecas=(na, nb),
+            ms2=na - nb,
+            verbose=verbose,
+        )
+        solver.binary = binary
+        mo_coeff = mf.mo_coeff
+        if isinstance(mo_coeff, (tuple, list)) and len(mo_coeff) == 2:
+            spin_mo_coeff = mo_coeff
+        else:
+            spin_mo_coeff = (mo_coeff, mo_coeff)
+        solver.mo_coeff = spin_mo_coeff
+        solver.mo_core, solver.mo_cas = _slice_active_orbitals(
+            solver.mo_coeff,
+            solver.ncore,
+            solver.ncas,
+        )
+        h1e, h2e = solver.get_SO_matrix(use_cholesky=use_cholesky)
+        h2e[0, 0] -= h2e[0, 0].swapaxes(1, 3)
+        h2e[1, 1] -= h2e[1, 1].swapaxes(1, 3)
+        sc1, sc2 = SlaterCondon(binary)
+        h_cis = CI_H(binary, h1e, h2e, sc1, sc2)
+        e_active, vecs = np.linalg.eigh(0.5 * (h_cis + h_cis.conj().T))
+        order = np.argsort(e_active.real)[:nstates]
+        e_active = e_active[order].real
+        vecs = vecs[:, order]
+        solver.solver_backend = "tdcis_dense_subspace"
+        solver.hcore = h1e
+        solver.eri_so = h2e
+        solver.h2e_cas = None
+        solver.SC1 = sc1
+        solver.SC2 = sc2
+        solver.H = h_cis
+        solver.e_tot = e_active + solver.e_core
+        solver.ci = [vecs[:, i] for i in range(vecs.shape[1])]
+        solver.nstates = int(vecs.shape[1])
+        solver.ci_sigma = lambda c, h=h_cis: h @ np.asarray(c)
+        solver.ci_diagonal = lambda h=h_cis: np.diag(h)
+        self.solver = solver
+        self.cis_binary = binary
+        self.nstates = nstates
+        super().__init__(
+            solver,
+            interaction_mo=interaction_mo,
+            field=field,
+            h1_mo=h1_mo,
+        )
+
+
+__all__ = ["TDCIS", "cis_determinant_basis"]

--- a/pyqed/superoperator.py
+++ b/pyqed/superoperator.py
@@ -14,7 +14,7 @@ Possible improvements:
 """
 import numpy as np
 from scipy.sparse import kron, identity, issparse
-from scipy.sparse.linalg import eigs
+from scipy.sparse.linalg import LinearOperator, eigs
 import scipy
 import math
 # from numba import jit
@@ -25,7 +25,7 @@ from pyqed import dag, pauli
 # from qutip import Qobj as Basic
 
 
-def liouvillian(H, c_ops):
+def liouvillian(H, c_ops=None, matrix_free=False):
     '''
     Construct the Liouvillian out of the Hamiltonian and collapse operators
 
@@ -35,6 +35,9 @@ def liouvillian(H, c_ops):
         DESCRIPTION.
     c_ops : TYPE
         DESCRIPTION.
+    matrix_free : bool, optional
+        If true, return a ``scipy.sparse.linalg.LinearOperator`` instead of
+        constructing the explicit Liouville-space matrix.
 
     Returns
     -------
@@ -42,10 +45,11 @@ def liouvillian(H, c_ops):
         DESCRIPTION.
 
     '''
-    # dissipator = 0.
-
     if c_ops is None:
         c_ops = []
+
+    if matrix_free:
+        return _matrix_free_liouvillian(H, c_ops)
 
     l = -1j * operator_to_superoperator(H)
 
@@ -55,6 +59,49 @@ def liouvillian(H, c_ops):
     # l = operator_to_superoperator(H) + 1j * dissipator
 
     return l
+
+
+def _matrix_free_liouvillian(H, c_ops=None):
+    """Return a matrix-free Lindblad Liouvillian as a ``LinearOperator``.
+
+    The operator uses the same row-major vectorization convention as
+    :func:`dm2vec` and :func:`liouvillian`, but applies the Lindblad RHS in
+    matrix form instead of constructing the explicit ``N**2 x N**2`` matrix.
+    """
+    if c_ops is None:
+        c_ops = []
+
+    dim = H.shape[-1]
+    shape = (dim * dim, dim * dim)
+    hamiltonian = H
+    collapse_ops = list(c_ops)
+    collapse_daggers = [dag(c_op) for c_op in collapse_ops]
+    collapse_products = [
+        c_dag @ c_op for c_dag, c_op in zip(collapse_daggers, collapse_ops)
+    ]
+    dtype = np.result_type(
+        getattr(H, "dtype", complex),
+        *[getattr(c_op, "dtype", complex) for c_op in collapse_ops],
+        complex,
+    )
+
+    def right_multiply(rho, operator):
+        return (operator.T @ rho.T).T
+
+    def matvec(vector):
+        rho = np.asarray(vector).reshape((dim, dim))
+        rhs = -1j * (hamiltonian @ rho - right_multiply(rho, hamiltonian))
+        for c_op, c_dag, c_dag_c in zip(
+            collapse_ops,
+            collapse_daggers,
+            collapse_products,
+        ):
+            jump = right_multiply(c_op @ rho, c_dag)
+            anticommutator = c_dag_c @ rho + right_multiply(rho, c_dag_c)
+            rhs = rhs + jump - 0.5 * anticommutator
+        return np.asarray(rhs).reshape(-1)
+
+    return LinearOperator(shape, matvec=matvec, dtype=dtype)
 
 class Qobj():
     def __init__(self, data=None, dims=None):
@@ -91,14 +138,14 @@ class Qobj():
     def to_vector(self):
         return operator_to_vector(self.data)
 
-    def to_super(self, type='commutator'):
+    def to_super(self, kind='commutator'):
 
-        return operator_to_superoperator(self.data, type=type)
+        return operator_to_superoperator(self.data, kind=kind)
 
-    def to_linblad(self, gamma=1.):
+    def to_lindblad(self, gamma=1.):
         l = self.data
         return gamma * (kron(l, l.conj()) - \
-                operator_to_superoperator(dag(l).dot(l), type='anticommutator'))
+                0.5 * operator_to_superoperator(dag(l).dot(l), kind='anticommutator'))
 
 
 def liouville_space(N):
@@ -405,7 +452,7 @@ def absorption(mol, omegas, c_ops):
 
     gamma = 0.02
 
-    l = op2sop(H) + 1j * c_op.to_linblad(gamma=gamma)
+    l = op2sop(H) + 1j * c_op.to_lindblad(gamma=gamma)
 
 
     ntrans = 3 * nstates # number of transitions
@@ -791,7 +838,7 @@ if __name__ == '__main__':
     c_op = dip
     gamma = 0.05
 
-    # l = h.to_super() + 1j * c_op.to_linblad(gamma=gamma)
+    # l = h.to_super() + 1j * c_op.to_lindblad(gamma=gamma)
     # l = liouvillian(H, c_ops=[gamma*c_op])
 
     # ntrans = 3 * nstates # number of transitions

--- a/tests/test_first_order_casscf.py
+++ b/tests/test_first_order_casscf.py
@@ -159,6 +159,29 @@ def test_second_order_orbital_pspace_prioritizes_critical_rotations():
     assert len(selected) == 3
 
 
+def test_second_order_batched_derivative_sigma_matches_direct_loop():
+    mf, mo_guess = _distorted_lih_reference()
+    mc = CASCI(mf, ncas=4, nelecas=4).run(
+        nstates=1,
+        mo_coeff=mo_guess,
+        method="direct_ci",
+    )
+    so = SecondOrderCASSCF(mf, ncas=4, nelecas=4)
+    h1_mo, eri_mo = so._get_integrals(mo_guess)
+    ci = mc.ci[0]
+
+    dh1_basis, deri_basis = so._active_integral_derivative_basis(mc, h1_mo, eri_mo)
+    reference = np.asarray(
+        [
+            so._make_active_sigma_casci(mc, dh1_basis[i], deri_basis[i]).ci_sigma(ci)
+            for i in range(dh1_basis.shape[0])
+        ]
+    )
+    batched = so._derivative_sigma_basis(mc, h1_mo, eri_mo, ci)
+
+    np.testing.assert_allclose(batched, reference, atol=1.0e-12)
+
+
 def test_davidson_augmented_hessian_can_return_diagnostics():
     grad = np.array([0.15, -0.05, 0.02])
     hdiag = np.array([0.8, 1.2, 1.5])

--- a/tests/test_gw_smoke.py
+++ b/tests/test_gw_smoke.py
@@ -214,7 +214,6 @@ def test_scgw_imaginary_axis_prototype_h2_shapes_are_finite():
     assert len(scgw.history) == 2
     assert len(scgw.mu_history) == 3
     assert scgw.info["method"] == "scgw_imaginary_axis_prototype"
-<<<<<<< HEAD
     assert scgw.info["grid"] == "tangent"
     assert scgw.info["adjust_mu"] is True
     assert scgw.info["total_energy"] == "galitskii_migdal"
@@ -224,12 +223,6 @@ def test_scgw_imaginary_axis_prototype_h2_shapes_are_finite():
     np.testing.assert_allclose(scgw.nelec, scgw.target_nelec, atol=1e-8)
     np.testing.assert_allclose(np.trace(scgw.density_matrix), scgw.nelec, atol=1e-10)
     assert np.isfinite(scgw.e_tot)
-=======
-    assert scgw.info["adjust_mu"] is True
-    assert scgw.info["total_energy"] == "not_implemented"
-    np.testing.assert_allclose(scgw.nelec, scgw.target_nelec, atol=1e-8)
-    np.testing.assert_allclose(np.trace(scgw.density_matrix), scgw.nelec, atol=1e-10)
->>>>>>> d6d6e73f3eb01265d5d7bf89f474427f6a1ea1d4
     assert np.all(np.isfinite(scgw.e_qp))
     assert np.all(np.isfinite(scgw.G))
 
@@ -275,10 +268,7 @@ def test_gw_driver_exposes_scgw_and_scgw0():
     gw0 = GW(mf, screening="TDH", eta=1e-8).scgw0(
         nfreq=7,
         wmax=8.0,
-<<<<<<< HEAD
         grid="linear",
-=======
->>>>>>> d6d6e73f3eb01265d5d7bf89f474427f6a1ea1d4
         max_cycle=1,
         damping=0.5,
     )
@@ -293,11 +283,8 @@ def test_gw_driver_exposes_scgw_and_scgw0():
     assert gw.method == "scgw"
     assert gw0.scgw_result.info["update_screening"] is False
     assert gw.scgw_result.info["update_screening"] is True
-<<<<<<< HEAD
     assert gw0.scgw_result.info["grid"] == "linear"
     assert gw.scgw_result.info["grid"] == "tangent"
-=======
->>>>>>> d6d6e73f3eb01265d5d7bf89f474427f6a1ea1d4
     assert gw0.e_qp.shape == (gw0.nso // 2,)
     assert gw.e_qp.shape == (gw.nso // 2,)
     assert np.all(np.isfinite(np.asarray(gw0)))
@@ -327,7 +314,6 @@ def test_scgw_uses_factorized_backend_when_available():
     assert scgw.W.shape == scgw.P.shape
     assert np.all(np.isfinite(scgw.G))
     assert np.all(np.isfinite(scgw.Sigma_c))
-<<<<<<< HEAD
     assert np.isfinite(scgw.e_tot)
 
 
@@ -400,8 +386,6 @@ def test_scgw_frequency_convergence_scan_reports_grid_deltas():
     assert rows[1]["nfreq"] == 7
     assert np.all(np.isfinite(rows[1]["e_qp"]))
     assert np.isfinite(rows[1]["e_tot"])
-=======
->>>>>>> d6d6e73f3eb01265d5d7bf89f474427f6a1ea1d4
 
 
 def test_scgw_matsubara_density_matches_static_limit():

--- a/tests/test_integrate.py
+++ b/tests/test_integrate.py
@@ -1,0 +1,77 @@
+import numpy as np
+from scipy import linalg as la
+
+from pyqed.integrate import (
+    dop853,
+    expm_krylov,
+    krylov,
+    normalize_method,
+    solve_ivp,
+)
+
+
+def test_normalize_method_aliases():
+    assert normalize_method("dopri853") == "dop853"
+    assert normalize_method("expm_krylov") == "krylov"
+    assert normalize_method("RK4") == "rk4"
+
+
+def test_expm_krylov_matches_dense_expm():
+    matrix = np.array([[0.0, -1.0], [1.0, 0.0]], dtype=np.complex128)
+    y0 = np.array([1.0, 0.0], dtype=np.complex128)
+
+    actual = expm_krylov(lambda y: matrix @ y, y0, 0.3, krylov_dim=2)
+    expected = la.expm(0.3 * matrix) @ y0
+
+    np.testing.assert_allclose(actual, expected, atol=1.0e-14)
+
+
+def test_krylov_matches_dense_exponential_on_grid():
+    matrix = np.array([[-0.2, 0.0], [0.0, -0.7]], dtype=np.complex128)
+    y0 = np.array([1.0, 2.0], dtype=np.complex128)
+    t_eval = np.linspace(0.0, 0.5, 6)
+
+    sol = krylov(lambda y: matrix @ y, y0, t_eval, krylov_dim=2)
+
+    expected = np.array([la.expm(t * matrix) @ y0 for t in t_eval]).T
+    assert sol.success
+    np.testing.assert_allclose(sol.y, expected, atol=1.0e-14)
+
+
+def test_solve_ivp_dop853_exponential_decay():
+    t_eval = np.linspace(0.0, 1.0, 6)
+    y0 = np.array([1.0 + 0.0j])
+
+    sol = solve_ivp(
+        lambda _t, y: -0.5 * y,
+        y0,
+        t_eval,
+        method="DOP853",
+        rtol=1.0e-11,
+        atol=1.0e-13,
+    )
+
+    assert sol.success
+    assert sol.n_steps > 0
+    np.testing.assert_allclose(sol.y[0], np.exp(-0.5 * t_eval), atol=1.0e-11)
+
+
+def test_dop853_streams_observations_without_saving_states():
+    t_eval = np.linspace(0.0, 2.0, 21)
+    y0 = np.array([1.0 + 0.0j])
+
+    sol = dop853(
+        lambda _t, y: -0.5 * y,
+        y0,
+        t_eval,
+        rtol=1.0e-11,
+        atol=1.0e-13,
+        observer=lambda _t, y: y[0],
+        save=False,
+    )
+
+    assert sol.success
+    assert sol.y is None
+    assert sol.n_steps > 0
+    np.testing.assert_allclose(sol.observations, np.exp(-0.5 * t_eval), atol=1.0e-11)
+    np.testing.assert_allclose(sol.y_final, [np.exp(-1.0)], atol=1.0e-11)

--- a/tests/test_rys.py
+++ b/tests/test_rys.py
@@ -17,13 +17,21 @@ from pyqed.qchem.rys import (
     boys,
     contracted_eri_cartesian_rys,
     contracted_eri_pppp_rys,
+    contracted_eri_ppps_rys,
     contracted_eri_ppss_rys,
     contracted_eri_psss_rys,
     contracted_eri_psps_rys,
     contracted_eri_ssss_rys,
+    primitive_eri_pppp_block_rys,
+    primitive_eri_pppp_rys,
+    primitive_eri_ppps_block_rys,
+    primitive_eri_ppps_rys,
     primitive_eri_ppss_block_rys,
+    primitive_eri_ppss_rys,
     primitive_eri_psss_block_rys,
+    primitive_eri_psss_rys,
     primitive_eri_psps_block_rys,
+    primitive_eri_psps_rys,
     primitive_eri_ssss_rys,
     rys_roots_weights,
 )
@@ -121,6 +129,48 @@ def test_primitive_psss_block_matches_existing_primitive_eri():
         ]
     )
     np.testing.assert_allclose(block, refs, atol=1e-12, rtol=1e-12)
+
+
+def test_primitive_scalar_rys_wrappers_match_block_entries():
+    a = 0.5
+    b = 0.3
+    c = 0.4
+    d = 0.2
+    A = (0.1, -0.2, 0.3)
+    B = (0.0, 0.0, 1.1)
+    C = (0.2, -0.1, 0.3)
+    D = (0.4, 0.3, -0.2)
+
+    np.testing.assert_allclose(
+        primitive_eri_psss_rys((1, 0, 0), a, A, b, B, c, C, d, D),
+        primitive_eri_psss_block_rys(a, A, b, B, c, C, d, D)[0],
+        atol=1e-12,
+        rtol=1e-12,
+    )
+    np.testing.assert_allclose(
+        primitive_eri_ppss_rys((1, 0, 0), a, A, (0, 0, 1), b, B, c, C, d, D),
+        primitive_eri_ppss_block_rys(a, A, b, B, c, C, d, D)[0, 2],
+        atol=1e-12,
+        rtol=1e-12,
+    )
+    np.testing.assert_allclose(
+        primitive_eri_psps_rys((1, 0, 0), a, A, b, B, (0, 1, 0), c, C, d, D),
+        primitive_eri_psps_block_rys(a, A, b, B, c, C, d, D)[0, 1],
+        atol=1e-12,
+        rtol=1e-12,
+    )
+    np.testing.assert_allclose(
+        primitive_eri_ppps_rys((1, 0, 0), a, A, (0, 0, 1), b, B, (0, 1, 0), c, C, d, D),
+        primitive_eri_ppps_block_rys(a, A, b, B, c, C, d, D)[0, 2, 1],
+        atol=1e-12,
+        rtol=1e-12,
+    )
+    np.testing.assert_allclose(
+        primitive_eri_pppp_rys((1, 0, 0), a, A, (0, 0, 1), b, B, (0, 1, 0), c, C, (1, 0, 0), d, D),
+        primitive_eri_pppp_block_rys(a, A, b, B, c, C, d, D)[0, 2, 1, 0],
+        atol=1e-12,
+        rtol=1e-12,
+    )
 
 
 def test_primitive_ppss_block_matches_existing_primitive_eri():
@@ -394,6 +444,88 @@ def test_contracted_psps_rys_matches_existing_contracted_eri():
 
     ref = ERI(a, b, c, d)
     val = contracted_eri_psps_rys(a, b, c, d)
+    np.testing.assert_allclose(val, ref, atol=1e-12, rtol=1e-12)
+
+
+def test_primitive_ppps_block_matches_existing_primitive_eri():
+    a = 0.5
+    b = 0.3
+    c = 0.4
+    d = 0.2
+    A = (0.1, -0.2, 0.3)
+    B = (0.0, 0.0, 1.1)
+    C = (0.2, -0.1, 0.3)
+    D = (0.4, 0.3, -0.2)
+
+    shells = [(1, 0, 0), (0, 1, 0), (0, 0, 1)]
+    block = primitive_eri_ppps_block_rys(a, A, b, B, c, C, d, D)
+    refs = np.zeros((3, 3, 3), dtype=float)
+    for i, sh_a in enumerate(shells):
+        for j, sh_b in enumerate(shells):
+            for k, sh_c in enumerate(shells):
+                refs[i, j, k] = electron_repulsion(
+                    a, sh_a, A,
+                    b, sh_b, B,
+                    c, sh_c, C,
+                    d, (0, 0, 0), D,
+                )
+    np.testing.assert_allclose(block, refs, atol=1e-12, rtol=1e-12)
+
+
+def test_primitive_pppp_block_matches_existing_primitive_eri():
+    a = 0.5
+    b = 0.3
+    c = 0.4
+    d = 0.2
+    A = (0.1, -0.2, 0.3)
+    B = (0.0, 0.0, 1.1)
+    C = (0.2, -0.1, 0.3)
+    D = (0.4, 0.3, -0.2)
+
+    shells = [(1, 0, 0), (0, 1, 0), (0, 0, 1)]
+    block = primitive_eri_pppp_block_rys(a, A, b, B, c, C, d, D)
+    refs = np.zeros((3, 3, 3, 3), dtype=float)
+    for i, sh_a in enumerate(shells):
+        for j, sh_b in enumerate(shells):
+            for k, sh_c in enumerate(shells):
+                for l, sh_d in enumerate(shells):
+                    refs[i, j, k, l] = electron_repulsion(
+                        a, sh_a, A,
+                        b, sh_b, B,
+                        c, sh_c, C,
+                        d, sh_d, D,
+                    )
+    np.testing.assert_allclose(block, refs, atol=1e-12, rtol=1e-12)
+
+
+def test_contracted_ppps_rys_matches_existing_contracted_eri():
+    a = ContractedGaussian(
+        origin=[0.0, 0.1, -0.1],
+        shell=(1, 0, 0),
+        exps=[0.6, 0.2],
+        coefs=[0.7, 0.4],
+    )
+    b = ContractedGaussian(
+        origin=[0.0, 0.0, 1.4],
+        shell=(0, 0, 1),
+        exps=[0.5, 0.15],
+        coefs=[0.6, 0.3],
+    )
+    c = ContractedGaussian(
+        origin=[0.2, 0.1, -0.2],
+        shell=(0, 1, 0),
+        exps=[0.7, 0.25],
+        coefs=[0.5, 0.2],
+    )
+    d = ContractedGaussian(
+        origin=[-0.3, 0.2, 0.4],
+        shell=(0, 0, 0),
+        exps=[0.8, 0.3],
+        coefs=[0.4, 0.25],
+    )
+
+    ref = ERI(a, b, c, d)
+    val = contracted_eri_ppps_rys(a, b, c, d)
     np.testing.assert_allclose(val, ref, atol=1e-12, rtol=1e-12)
 
 

--- a/tests/test_superoperator_lindblad.py
+++ b/tests/test_superoperator_lindblad.py
@@ -1,0 +1,89 @@
+import numpy as np
+import scipy.sparse as sp
+
+from pyqed import dag
+from pyqed.superoperator import (
+    Qobj,
+    dm2vec,
+    lindblad_dissipator,
+    liouvillian,
+)
+
+
+def _random_hermitian(rng, dim):
+    matrix = rng.normal(size=(dim, dim)) + 1j * rng.normal(size=(dim, dim))
+    return 0.5 * (matrix + matrix.conj().T)
+
+
+def test_lindblad_superoperator_matches_matrix_rhs():
+    rng = np.random.default_rng(4)
+    dim = 3
+    hamiltonian = _random_hermitian(rng, dim)
+    collapse = rng.normal(size=(dim, dim)) + 1j * rng.normal(size=(dim, dim))
+    rho = _random_hermitian(rng, dim)
+
+    super_rhs = liouvillian(hamiltonian, [collapse]) @ dm2vec(rho)
+    matrix_rhs = (
+        -1j * (hamiltonian @ rho - rho @ hamiltonian)
+        + collapse @ rho @ dag(collapse)
+        - 0.5 * ((dag(collapse) @ collapse) @ rho + rho @ (dag(collapse) @ collapse))
+    )
+
+    np.testing.assert_allclose(super_rhs, matrix_rhs.reshape(-1), atol=1.0e-12)
+
+
+def test_lindblad_superoperator_is_trace_preserving():
+    rng = np.random.default_rng(8)
+    dim = 4
+    hamiltonian = _random_hermitian(rng, dim)
+    collapse = rng.normal(size=(dim, dim)) + 1j * rng.normal(size=(dim, dim))
+
+    generator = liouvillian(hamiltonian, [collapse]).toarray()
+    trace_vector = np.eye(dim).reshape(-1)
+
+    np.testing.assert_allclose(trace_vector.conj() @ generator, 0.0, atol=1.0e-12)
+
+
+def test_qobj_lindblad_helper_matches_free_function():
+    rng = np.random.default_rng(12)
+    collapse = rng.normal(size=(3, 3)) + 1j * rng.normal(size=(3, 3))
+    gamma = 0.37
+
+    helper = Qobj(collapse).to_lindblad(gamma=gamma).toarray()
+    expected = (gamma * lindblad_dissipator(collapse)).toarray()
+
+    np.testing.assert_allclose(helper, expected, atol=1.0e-12)
+
+
+def test_matrix_free_liouvillian_matches_explicit_superoperator():
+    rng = np.random.default_rng(16)
+    dim = 3
+    hamiltonian = _random_hermitian(rng, dim)
+    collapse_ops = [
+        rng.normal(size=(dim, dim)) + 1j * rng.normal(size=(dim, dim))
+        for _ in range(2)
+    ]
+    rho = _random_hermitian(rng, dim)
+    vec = dm2vec(rho)
+
+    explicit = liouvillian(hamiltonian, collapse_ops)
+    matrix_free = liouvillian(hamiltonian, collapse_ops, matrix_free=True)
+
+    assert matrix_free.shape == explicit.shape
+    np.testing.assert_allclose(matrix_free @ vec, explicit @ vec, atol=1.0e-12)
+
+
+def test_matrix_free_liouvillian_accepts_sparse_operators():
+    rng = np.random.default_rng(20)
+    dim = 4
+    hamiltonian = sp.csr_matrix(_random_hermitian(rng, dim))
+    collapse_ops = [
+        sp.csr_matrix(rng.normal(size=(dim, dim)) + 1j * rng.normal(size=(dim, dim)))
+    ]
+    rho = _random_hermitian(rng, dim)
+    vec = dm2vec(rho)
+
+    explicit = liouvillian(hamiltonian, collapse_ops)
+    matrix_free = liouvillian(hamiltonian, collapse_ops, matrix_free=True)
+
+    np.testing.assert_allclose(matrix_free @ vec, explicit @ vec, atol=1.0e-12)

--- a/tests/test_tdcasci.py
+++ b/tests/test_tdcasci.py
@@ -1,0 +1,95 @@
+import numpy as np
+
+from pyqed.qchem import Molecule, TDCASCI
+from pyqed.qchem.hf import RHF
+from pyqed.qchem.mcscf.direct_ci import CASCI
+
+
+def _h2_casci(nstates=4):
+    mol = Molecule(atom="H 0 0 0; H 0 0 1.4", unit="bohr", basis="sto-3g")
+    mol.build(driver="gbasis")
+    mf = RHF(mol).run()
+    return CASCI(mf, ncas=2, nelecas=2, verbose=0).run(
+        nstates=nstates,
+        method="direct_ci",
+    )
+
+
+def test_tdcasci_is_exported_without_old_rt_names():
+    from pyqed.qchem.tdcasci import TDCASCI as DirectTDCASCI
+    import pyqed.qchem as qchem
+
+    assert TDCASCI is DirectTDCASCI
+    assert not hasattr(qchem, "RTCASCI")
+    assert not hasattr(qchem, "RealTimeCASCI")
+
+
+def test_tdcasci_field_free_preserves_norm_energy_phase_and_populations():
+    mc = _h2_casci(nstates=4)
+    td = TDCASCI(mc)
+
+    traj = td.run(dt=0.07, nsteps=8, ci0=0)
+
+    np.testing.assert_allclose(traj.norms, 1.0, atol=1.0e-12)
+    np.testing.assert_allclose(traj.energies, mc.e_tot[0], atol=1.0e-10)
+    np.testing.assert_allclose(traj.populations[:, 0], 1.0, atol=1.0e-10)
+    np.testing.assert_allclose(traj.populations[:, 1:], 0.0, atol=1.0e-10)
+
+    active_e = float(mc.e_tot[0] - mc.e_core)
+    phase = np.exp(-1j * active_e * traj.times)
+    reference = phase[:, None] * np.asarray(mc.ci[0], dtype=complex)[None, :]
+    np.testing.assert_allclose(traj.ci, reference, atol=1.0e-10)
+
+
+def test_tdcasci_state_basis_matches_determinant_basis_for_field_free_state():
+    mc = _h2_casci(nstates=4)
+    td = TDCASCI(mc)
+
+    det_traj = td.run(dt=0.05, nsteps=6, ci0=1)
+    state_traj = td.run(dt=0.05, nsteps=6, ci0=1, basis="state", nstates=4)
+
+    np.testing.assert_allclose(state_traj.norms, 1.0, atol=1.0e-12)
+    np.testing.assert_allclose(state_traj.populations[:, 1], 1.0, atol=1.0e-10)
+    np.testing.assert_allclose(state_traj.ci, det_traj.ci, atol=1.0e-10)
+
+
+def test_tdcasci_kick_and_spectrum_helpers():
+    mc = _h2_casci(nstates=4)
+    td = TDCASCI(mc)
+
+    traj = td.run(
+        dt=0.05,
+        nsteps=8,
+        ci0=0,
+        kick={"strength": 1.0e-3, "axis": "z"},
+    )
+
+    np.testing.assert_allclose(traj.norms, 1.0, atol=1.0e-12)
+    assert np.max(np.abs(traj.dipoles[:, 2])) > 1.0e-6
+    omega, power = traj.dipole_spectrum(axis="z")
+    assert omega.shape == power.shape
+    assert np.all(power >= 0.0)
+    corr_omega, corr_power = traj.autocorrelation_spectrum()
+    assert corr_omega.shape == corr_power.shape
+
+
+def test_tdcasci_accepts_general_time_dependent_one_body_drive():
+    mc = _h2_casci(nstates=4)
+    td = TDCASCI(mc)
+    ncas = mc.ncas
+    drive = np.zeros((ncas, ncas))
+    drive[0, 1] = drive[1, 0] = 0.02
+
+    def h1(time):
+        return np.sin(0.3 * time) * drive
+
+    h_early = td.one_body_hamiltonian_matrix(0.2, h1_mo=h1)
+    h_late = td.one_body_hamiltonian_matrix(0.8, h1_mo=h1)
+    assert not np.allclose(h_early, h_late)
+    assert td._one_body_cache == {}
+
+    traj = td.run(dt=0.05, nsteps=6, ci0=0, h1_mo=h1)
+
+    np.testing.assert_allclose(traj.norms, 1.0, atol=1.0e-12)
+    assert traj.ci.shape == (7, mc.binary.shape[0])
+    assert td._one_body_cache == {}

--- a/tests/test_tdcis.py
+++ b/tests/test_tdcis.py
@@ -1,0 +1,55 @@
+import numpy as np
+
+from pyqed.qchem import Molecule, TDCIS, cis_determinant_basis
+from pyqed.qchem.hf import RHF
+from pyqed.qchem.tdcis import TDCIS as DirectTDCIS
+
+
+def _h2_rhf():
+    mol = Molecule(atom="H 0 0 0; H 0 0 1.4", unit="bohr", basis="sto-3g")
+    mol.build(driver="gbasis")
+    return RHF(mol).run()
+
+
+def test_tdcis_is_exported():
+    assert TDCIS is DirectTDCIS
+
+
+def test_cis_determinant_basis_contains_reference_and_singles():
+    mf = _h2_rhf()
+    binary = cis_determinant_basis(mf)
+
+    nocc = int(np.count_nonzero(np.asarray(mf.mo_occ) > 0))
+    nvir = int(mf.nmo - nocc)
+    assert binary.shape == (1 + 2 * nocc * nvir, 2, mf.nmo)
+    np.testing.assert_array_equal(binary[0, 0], np.array([1, 0], dtype=np.int8))
+    np.testing.assert_array_equal(binary[0, 1], np.array([1, 0], dtype=np.int8))
+    assert all(np.sum(det[0]) == nocc for det in binary)
+    assert all(np.sum(det[1]) == nocc for det in binary)
+
+
+def test_tdcis_field_free_preserves_norm_and_populations():
+    mf = _h2_rhf()
+    td = TDCIS(mf, nstates=3)
+
+    traj = td.run(dt=0.05, nsteps=6, ci0=0)
+
+    np.testing.assert_allclose(traj.norms, 1.0, atol=1.0e-12)
+    np.testing.assert_allclose(traj.populations[:, 0], 1.0, atol=1.0e-10)
+    np.testing.assert_allclose(traj.populations[:, 1:], 0.0, atol=1.0e-10)
+    assert traj.ci.shape == (7, td.cis_binary.shape[0])
+
+
+def test_tdcis_kick_generates_response():
+    mf = _h2_rhf()
+    td = TDCIS(mf, nstates=3)
+
+    traj = td.run(
+        dt=0.05,
+        nsteps=8,
+        ci0=0,
+        kick={"strength": 1.0e-3, "axis": "z"},
+    )
+
+    np.testing.assert_allclose(traj.norms, 1.0, atol=1.0e-12)
+    assert np.max(np.abs(traj.dipoles[:, 2])) > 1.0e-6


### PR DESCRIPTION
## Summary

- add the official PyQED paper metadata and DOI to `CITATION.cff`, the README, and the documentation
- add the published Zenodo software DOIs for v0.2.0 and the all-versions archive, with corrected software-author metadata
- add a privacy-preserving documentation page-view beacon for the first-party `pyqed.org` aggregate endpoint
- recover focused ODE integration, Lindblad/matrix-free superoperator, TD-CIS, and TD-CASCI work from the damaged local checkout
- recover targeted CASSCF/Rys regressions and remove unresolved GW conflict markers
- harden CI/release workflows against merge markers and version-specific artifact filenames

## Validation

- `git diff --check` and merge-marker audit: clean
- changed Python files compile; CFF and workflow YAML parse
- focused recovery tests: 19 passed
- resolved SCGW tests: 7 passed (30 deselected)
- combined relevant focused run: 88 passed
- strict Sphinx documentation build with warnings as errors: passed
- both Zenodo DOI resolvers return the public v0.2.0 record

A broader targeted run still exposes pre-existing GW dense-ERI backend/reference failures and one very narrow CASSCF gradient threshold miss; none are caused by the recovered modules in this PR.