### PR TITLE
fix: resolve GW markers and harden release CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,22 @@ env:
   MPLBACKEND: Agg
 
 jobs:
+  hygiene:
+    name: Repository hygiene
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+      - name: Reject unresolved merge markers
+        run: |
+          if git grep -nE '^(<<<<<<< |>>>>>>> )' -- '*.py' '*.pyx' '*.rst' '*.md' '*.toml' '*.yml' '*.yaml'; then
+            echo "Unresolved merge-conflict markers found."
+            exit 1
+          fi
+
   core:
     name: Core / Python ${{ matrix.python-version }}
+    needs: hygiene
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -43,6 +57,7 @@ jobs:
 
   native-extensions:
     name: Optional native extensions
+    needs: hygiene
     runs-on: ubuntu-latest
     env:
       PYQED_BUILD_EXTENSIONS: "1"
@@ -64,6 +79,7 @@ jobs:
 
   heom-extra:
     name: HEOM optional dependencies
+    needs: hygiene
     runs-on: ubuntu-latest
 
     steps:
@@ -80,6 +96,7 @@ jobs:
 
   distribution:
     name: Wheel and source distribution
+    needs: hygiene
     runs-on: ubuntu-latest
 
     steps:
@@ -99,21 +116,22 @@ jobs:
         run: |
           python -m venv /tmp/pyqed-wheel
           /tmp/pyqed-wheel/bin/python -m pip install --upgrade pip
-          /tmp/pyqed-wheel/bin/python -m pip install dist/pyqed-0.2.0-py3-none-any.whl
+          /tmp/pyqed-wheel/bin/python -m pip install dist/*.whl
           cd /tmp
           /tmp/pyqed-wheel/bin/python "$GITHUB_WORKSPACE/examples/quickstart.py"
-          /tmp/pyqed-wheel/bin/python -c 'from importlib.metadata import version; from importlib.util import find_spec; from pathlib import Path; import pyqed; from pyqed.gw import BSE, GW, TDA; from pyqed.namd import TDDFTDriver; from pyqed.qchem import MP2, Molecule; from pyqed.qchem.basis import _basis_path; from pyqed.qchem.dft import RKS; names=("pyqed.HEOM", "pyqed.HEOM.deom", "pyqed.floquet", "pyqed.gw", "pyqed.md", "pyqed.ml", "pyqed.namd", "pyqed.narg", "pyqed.mps.nonabelian", "pyqed.qchem.dft", "pyqed.qchem.mp"); assert pyqed.__version__ == version("pyqed") == "0.2.0"; assert Path(_basis_path("sto-3g")).is_file(); assert all(find_spec(name) is not None for name in names); assert all(item is not None for item in (BSE, GW, TDA, MP2, Molecule, RKS, TDDFTDriver))'
+          /tmp/pyqed-wheel/bin/python -c 'from importlib.metadata import version; from importlib.util import find_spec; from pathlib import Path; import pyqed; from pyqed.gw import BSE, GW, TDA; from pyqed.namd import TDDFTDriver; from pyqed.qchem import MP2, Molecule; from pyqed.qchem.basis import _basis_path; from pyqed.qchem.dft import RKS; names=("pyqed.HEOM", "pyqed.HEOM.deom", "pyqed.floquet", "pyqed.gw", "pyqed.md", "pyqed.ml", "pyqed.namd", "pyqed.narg", "pyqed.mps.nonabelian", "pyqed.qchem.dft", "pyqed.qchem.mp"); assert pyqed.__version__ == version("pyqed"); assert Path(_basis_path("sto-3g")).is_file(); assert all(find_spec(name) is not None for name in names); assert all(item is not None for item in (BSE, GW, TDA, MP2, Molecule, RKS, TDDFTDriver))'
           /tmp/pyqed-wheel/bin/python -m compileall -q /tmp/pyqed-wheel/lib/python3.13/site-packages/pyqed
       - name: Install and test the source distribution in isolation
         run: |
           python -m venv /tmp/pyqed-sdist
           /tmp/pyqed-sdist/bin/python -m pip install --upgrade pip
-          /tmp/pyqed-sdist/bin/python -m pip install dist/pyqed-0.2.0.tar.gz
+          /tmp/pyqed-sdist/bin/python -m pip install dist/*.tar.gz
           cd /tmp
           /tmp/pyqed-sdist/bin/python "$GITHUB_WORKSPACE/examples/quickstart.py"
 
   docs:
     name: Documentation
+    needs: hygiene
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+      - name: Reject unresolved merge markers
+        run: |
+          if git grep -nE '^(<<<<<<< |>>>>>>> )' -- '*.py' '*.pyx' '*.rst' '*.md' '*.toml' '*.yml' '*.yaml'; then
+            echo "Unresolved merge-conflict markers found."
+            exit 1
+          fi
       - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
@@ -69,7 +75,7 @@ jobs:
         run: |
           python -m venv /tmp/pyqed-release
           /tmp/pyqed-release/bin/python -m pip install --upgrade pip
-          /tmp/pyqed-release/bin/python -m pip install dist/pyqed-0.2.0-py3-none-any.whl
+          /tmp/pyqed-release/bin/python -m pip install dist/*.whl
           cd /tmp
           /tmp/pyqed-release/bin/python "$GITHUB_WORKSPACE/examples/quickstart.py"
           /tmp/pyqed-release/bin/python -c 'from importlib.metadata import version; from importlib.util import find_spec; import pyqed; from pyqed.gw import BSE, GW, TDA; from pyqed.namd import TDDFTDriver; from pyqed.qchem import MP2, Molecule; from pyqed.qchem.dft import RKS; names=("pyqed.HEOM", "pyqed.HEOM.deom", "pyqed.floquet", "pyqed.gw", "pyqed.md", "pyqed.ml", "pyqed.namd", "pyqed.narg", "pyqed.mps.nonabelian", "pyqed.qchem.dft", "pyqed.qchem.mp"); assert pyqed.__version__ == version("pyqed"); assert all(find_spec(name) is not None for name in names); assert all(item is not None for item in (BSE, GW, TDA, MP2, Molecule, RKS, TDDFTDriver))'

--- a/tests/test_gw_smoke.py
+++ b/tests/test_gw_smoke.py
@@ -214,7 +214,6 @@ def test_scgw_imaginary_axis_prototype_h2_shapes_are_finite():
     assert len(scgw.history) == 2
     assert len(scgw.mu_history) == 3
     assert scgw.info["method"] == "scgw_imaginary_axis_prototype"
-<<<<<<< HEAD
     assert scgw.info["grid"] == "tangent"
     assert scgw.info["adjust_mu"] is True
     assert scgw.info["total_energy"] == "galitskii_migdal"
@@ -224,12 +223,6 @@ def test_scgw_imaginary_axis_prototype_h2_shapes_are_finite():
     np.testing.assert_allclose(scgw.nelec, scgw.target_nelec, atol=1e-8)
     np.testing.assert_allclose(np.trace(scgw.density_matrix), scgw.nelec, atol=1e-10)
     assert np.isfinite(scgw.e_tot)
-=======
-    assert scgw.info["adjust_mu"] is True
-    assert scgw.info["total_energy"] == "not_implemented"
-    np.testing.assert_allclose(scgw.nelec, scgw.target_nelec, atol=1e-8)
-    np.testing.assert_allclose(np.trace(scgw.density_matrix), scgw.nelec, atol=1e-10)
->>>>>>> d6d6e73f3eb01265d5d7bf89f474427f6a1ea1d4
     assert np.all(np.isfinite(scgw.e_qp))
     assert np.all(np.isfinite(scgw.G))
 
@@ -275,10 +268,7 @@ def test_gw_driver_exposes_scgw_and_scgw0():
     gw0 = GW(mf, screening="TDH", eta=1e-8).scgw0(
         nfreq=7,
         wmax=8.0,
-<<<<<<< HEAD
         grid="linear",
-=======
->>>>>>> d6d6e73f3eb01265d5d7bf89f474427f6a1ea1d4
         max_cycle=1,
         damping=0.5,
     )
@@ -293,11 +283,8 @@ def test_gw_driver_exposes_scgw_and_scgw0():
     assert gw.method == "scgw"
     assert gw0.scgw_result.info["update_screening"] is False
     assert gw.scgw_result.info["update_screening"] is True
-<<<<<<< HEAD
     assert gw0.scgw_result.info["grid"] == "linear"
     assert gw.scgw_result.info["grid"] == "tangent"
-=======
->>>>>>> d6d6e73f3eb01265d5d7bf89f474427f6a1ea1d4
     assert gw0.e_qp.shape == (gw0.nso // 2,)
     assert gw.e_qp.shape == (gw.nso // 2,)
     assert np.all(np.isfinite(np.asarray(gw0)))
@@ -327,7 +314,6 @@ def test_scgw_uses_factorized_backend_when_available():
     assert scgw.W.shape == scgw.P.shape
     assert np.all(np.isfinite(scgw.G))
     assert np.all(np.isfinite(scgw.Sigma_c))
-<<<<<<< HEAD
     assert np.isfinite(scgw.e_tot)
 
 
@@ -400,8 +386,6 @@ def test_scgw_frequency_convergence_scan_reports_grid_deltas():
     assert rows[1]["nfreq"] == 7
     assert np.all(np.isfinite(rows[1]["e_qp"]))
     assert np.isfinite(rows[1]["e_tot"])
-=======
->>>>>>> d6d6e73f3eb01265d5d7bf89f474427f6a1ea1d4
 
 
 def test_scgw_matsubara_density_matches_static_limit():


### PR DESCRIPTION
## Summary

- resolve committed merge markers in the SCGW smoke tests
- reject unresolved merge markers before CI, docs, distribution, and release jobs
- make wheel/sdist install checks version-agnostic

This is the first focused replacement for the oversized recovery PR #55.

## Validation

- `pytest -q tests/test_gw_smoke.py -k scgw` — 7 passed
- both workflow files parse as YAML
- `git diff --check` passes
- repository merge-marker scan passes

## Review note

Merge this before the remaining focused PRs because the new hygiene job would reject the conflict markers currently committed on `main`.