### PR TITLE
docs: publish PyQED paper and software DOIs

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,8 @@
 cff-version: 1.2.0
 message: >-
-  If you use PyQED, please cite the exact software release or Git commit and
-  the method-specific references for the algorithms used.
+  If you use PyQED, please cite the exact software release or Git commit, the
+  preferred project paper below, and the method-specific references for the
+  algorithms used.
 title: PyQED
 type: software
 version: 0.2.0
@@ -9,8 +10,25 @@ date-released: 2026-07-11
 authors:
   - family-names: Gu
     given-names: Bing
-  - family-names: Chen
-    given-names: Zihao
+preferred-citation:
+  type: article
+  title: "PyQED: A Python Framework for Ab Initio Geometric Quantum Dynamics"
+  authors:
+    - family-names: Xie
+      given-names: Yujuan
+    - family-names: Zhu
+      given-names: Xiaotong
+    - family-names: Gu
+      given-names: Bing
+  journal: "Chinese Journal of Chemical Physics"
+  year: 2026
+  doi: "10.1063/1674-0068/cjcp2510161"
+  url: "https://doi.org/10.1063/1674-0068/cjcp2510161"
 repository-code: https://github.com/binggu56/pyqed
 url: https://pyqed.org
+doi: "10.5281/zenodo.21316544"
+identifiers:
+  - type: doi
+    value: "10.5281/zenodo.21316543"
+    description: "PyQED software archive (all versions)"
 license: MIT

--- a/README.rst
+++ b/README.rst
@@ -111,10 +111,22 @@ Citing PyQED
 ------------
 
 Use the metadata in ``CITATION.cff`` and record the exact PyQED release or Git
-commit used.  No project DOI is asserted until one appears in an archived
-release.  See the `citation guide
-<https://docs.pyqed.org/en/latest/citing.html>`_ for a reproducibility
-checklist.
+commit used.  The archived software has two DOI forms:
+
+* all PyQED versions: https://doi.org/10.5281/zenodo.21316543;
+* exact v0.2.0 archive: https://doi.org/10.5281/zenodo.21316544.
+
+Use the version-specific DOI when citing v0.2.0, and use the all-versions DOI
+when you want a citation that resolves to the latest archived release.  Also
+cite the project paper:
+
+  Yujuan Xie, Xiaotong Zhu, and Bing Gu, “PyQED: A Python Framework for
+  *Ab Initio* Geometric Quantum Dynamics,” *Chinese Journal of Chemical
+  Physics* (2026), https://doi.org/10.1063/1674-0068/cjcp2510161.
+
+The article DOI is distinct from both software-archive DOIs.  See the
+`citation guide <https://docs.pyqed.org/en/latest/citing.html>`_ for
+method-citation and reproducibility guidance.
 
 License
 -------

--- a/docs/source/citing.rst
+++ b/docs/source/citing.rst
@@ -17,9 +17,28 @@ control can render that metadata.  A reproducible citation should include:
 * the repository URL, https://github.com/binggu56/pyqed; and
 * the access or release year required by the target citation style.
 
-No project DOI is asserted in the repository at present.  If a future release
-is deposited in an archive, use the DOI shown by that specific archived
-release; do not infer or reuse a placeholder DOI.
+The Zenodo software archive provides:
+
+* an all-versions DOI, https://doi.org/10.5281/zenodo.21316543; and
+* an exact v0.2.0 DOI, https://doi.org/10.5281/zenodo.21316544.
+
+Use the version-specific DOI when citing v0.2.0.  Use the all-versions DOI for
+a general PyQED citation that should resolve to the latest archived release.
+
+Project paper
+-------------
+
+In addition to the exact software release or commit, cite the PyQED project
+paper:
+
+  Yujuan Xie, Xiaotong Zhu, and Bing Gu, “PyQED: A Python Framework for
+  *Ab Initio* Geometric Quantum Dynamics,” *Chinese Journal of Chemical
+  Physics* (2026), https://doi.org/10.1063/1674-0068/cjcp2510161.
+
+The DOI above identifies the journal article, not an archived software
+release.  It is distinct from both Zenodo software DOIs.  For a reproducible
+software citation, use the DOI shown by the specific archived release; do not
+reuse the article DOI.
 
 Method citations
 ----------------


### PR DESCRIPTION
## Summary

- add the PyQED paper DOI and Zenodo software DOI to `CITATION.cff`
- distinguish the exact v0.2.0 DOI from the all-versions concept DOI
- publish corrected software authorship and citation guidance in the README and docs

This is a focused replacement for the citation portion of #55.

## Validation

- `CITATION.cff` parses as YAML and contains the expected DOI metadata
- strict Sphinx build: `python -m sphinx -W -b html docs/source ...`
- `git diff --check` passes