### PR TITLE
docs: add source browser and first-party analytics

### DIFF
--- a/docs/_static/analytics.js
+++ b/docs/_static/analytics.js
@@ -1,0 +1,14 @@
+(() => {
+  const endpoint = "https://pyqed.org/api/analytics";
+  const event = "docs_pageview";
+  const payload = new Blob([event], { type: "text/plain;charset=UTF-8" });
+
+  if (navigator.sendBeacon?.(endpoint, payload)) return;
+
+  void fetch(endpoint, {
+    method: "POST",
+    body: event,
+    headers: { "Content-Type": "text/plain;charset=UTF-8" },
+    keepalive: true,
+  });
+})();

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -45,6 +45,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.napoleon',
     'sphinx.ext.mathjax',
+    'sphinx.ext.viewcode',
 ]
 
 #.. autoclass:: lime.oqs.LindbladSolver
@@ -106,3 +107,4 @@ html_baseurl = os.environ.get(
 # so a file named "default.css" will overwrite the builtin "default.css".
 _static_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '_static'))
 html_static_path = ['../_static'] if os.path.isdir(_static_path) else []
+html_js_files = ['analytics.js'] if html_static_path else []


### PR DESCRIPTION
## Summary

- enable Sphinx `viewcode`, giving API pages `[source]` links and a generated `_modules` browser
- add a minimal first-party documentation pageview beacon
- send only the fixed event name `docs_pageview`; no URL, referrer, cookie, or user identifier is collected

This follows PySCF's layered pattern: concise guides plus a separate generated source browser. It is a focused replacement for the docs/analytics portion of #55.

## Validation

- strict Sphinx build with `-W` passes
- generated `_modules/index.html` and module source page verified
- built HTML includes `analytics.js`
- beacon POST from `Origin: https://docs.pyqed.org` returns HTTP 204
- `git diff --check` passes