### PR TITLE
test: restore CASSCF and Rys regression coverage

### DIFF
--- a/tests/test_first_order_casscf.py
+++ b/tests/test_first_order_casscf.py
@@ -159,6 +159,29 @@ def test_second_order_orbital_pspace_prioritizes_critical_rotations():
     assert len(selected) == 3
 
 
+def test_second_order_batched_derivative_sigma_matches_direct_loop():
+    mf, mo_guess = _distorted_lih_reference()
+    mc = CASCI(mf, ncas=4, nelecas=4).run(
+        nstates=1,
+        mo_coeff=mo_guess,
+        method="direct_ci",
+    )
+    so = SecondOrderCASSCF(mf, ncas=4, nelecas=4)
+    h1_mo, eri_mo = so._get_integrals(mo_guess)
+    ci = mc.ci[0]
+
+    dh1_basis, deri_basis = so._active_integral_derivative_basis(mc, h1_mo, eri_mo)
+    reference = np.asarray(
+        [
+            so._make_active_sigma_casci(mc, dh1_basis[i], deri_basis[i]).ci_sigma(ci)
+            for i in range(dh1_basis.shape[0])
+        ]
+    )
+    batched = so._derivative_sigma_basis(mc, h1_mo, eri_mo, ci)
+
+    np.testing.assert_allclose(batched, reference, atol=1.0e-12)
+
+
 def test_davidson_augmented_hessian_can_return_diagnostics():
     grad = np.array([0.15, -0.05, 0.02])
     hdiag = np.array([0.8, 1.2, 1.5])

--- a/tests/test_rys.py
+++ b/tests/test_rys.py
@@ -17,13 +17,21 @@ from pyqed.qchem.rys import (
     boys,
     contracted_eri_cartesian_rys,
     contracted_eri_pppp_rys,
+    contracted_eri_ppps_rys,
     contracted_eri_ppss_rys,
     contracted_eri_psss_rys,
     contracted_eri_psps_rys,
     contracted_eri_ssss_rys,
+    primitive_eri_pppp_block_rys,
+    primitive_eri_pppp_rys,
+    primitive_eri_ppps_block_rys,
+    primitive_eri_ppps_rys,
     primitive_eri_ppss_block_rys,
+    primitive_eri_ppss_rys,
     primitive_eri_psss_block_rys,
+    primitive_eri_psss_rys,
     primitive_eri_psps_block_rys,
+    primitive_eri_psps_rys,
     primitive_eri_ssss_rys,
     rys_roots_weights,
 )
@@ -121,6 +129,48 @@ def test_primitive_psss_block_matches_existing_primitive_eri():
         ]
     )
     np.testing.assert_allclose(block, refs, atol=1e-12, rtol=1e-12)
+
+
+def test_primitive_scalar_rys_wrappers_match_block_entries():
+    a = 0.5
+    b = 0.3
+    c = 0.4
+    d = 0.2
+    A = (0.1, -0.2, 0.3)
+    B = (0.0, 0.0, 1.1)
+    C = (0.2, -0.1, 0.3)
+    D = (0.4, 0.3, -0.2)
+
+    np.testing.assert_allclose(
+        primitive_eri_psss_rys((1, 0, 0), a, A, b, B, c, C, d, D),
+        primitive_eri_psss_block_rys(a, A, b, B, c, C, d, D)[0],
+        atol=1e-12,
+        rtol=1e-12,
+    )
+    np.testing.assert_allclose(
+        primitive_eri_ppss_rys((1, 0, 0), a, A, (0, 0, 1), b, B, c, C, d, D),
+        primitive_eri_ppss_block_rys(a, A, b, B, c, C, d, D)[0, 2],
+        atol=1e-12,
+        rtol=1e-12,
+    )
+    np.testing.assert_allclose(
+        primitive_eri_psps_rys((1, 0, 0), a, A, b, B, (0, 1, 0), c, C, d, D),
+        primitive_eri_psps_block_rys(a, A, b, B, c, C, d, D)[0, 1],
+        atol=1e-12,
+        rtol=1e-12,
+    )
+    np.testing.assert_allclose(
+        primitive_eri_ppps_rys((1, 0, 0), a, A, (0, 0, 1), b, B, (0, 1, 0), c, C, d, D),
+        primitive_eri_ppps_block_rys(a, A, b, B, c, C, d, D)[0, 2, 1],
+        atol=1e-12,
+        rtol=1e-12,
+    )
+    np.testing.assert_allclose(
+        primitive_eri_pppp_rys((1, 0, 0), a, A, (0, 0, 1), b, B, (0, 1, 0), c, C, (1, 0, 0), d, D),
+        primitive_eri_pppp_block_rys(a, A, b, B, c, C, d, D)[0, 2, 1, 0],
+        atol=1e-12,
+        rtol=1e-12,
+    )
 
 
 def test_primitive_ppss_block_matches_existing_primitive_eri():
@@ -394,6 +444,88 @@ def test_contracted_psps_rys_matches_existing_contracted_eri():
 
     ref = ERI(a, b, c, d)
     val = contracted_eri_psps_rys(a, b, c, d)
+    np.testing.assert_allclose(val, ref, atol=1e-12, rtol=1e-12)
+
+
+def test_primitive_ppps_block_matches_existing_primitive_eri():
+    a = 0.5
+    b = 0.3
+    c = 0.4
+    d = 0.2
+    A = (0.1, -0.2, 0.3)
+    B = (0.0, 0.0, 1.1)
+    C = (0.2, -0.1, 0.3)
+    D = (0.4, 0.3, -0.2)
+
+    shells = [(1, 0, 0), (0, 1, 0), (0, 0, 1)]
+    block = primitive_eri_ppps_block_rys(a, A, b, B, c, C, d, D)
+    refs = np.zeros((3, 3, 3), dtype=float)
+    for i, sh_a in enumerate(shells):
+        for j, sh_b in enumerate(shells):
+            for k, sh_c in enumerate(shells):
+                refs[i, j, k] = electron_repulsion(
+                    a, sh_a, A,
+                    b, sh_b, B,
+                    c, sh_c, C,
+                    d, (0, 0, 0), D,
+                )
+    np.testing.assert_allclose(block, refs, atol=1e-12, rtol=1e-12)
+
+
+def test_primitive_pppp_block_matches_existing_primitive_eri():
+    a = 0.5
+    b = 0.3
+    c = 0.4
+    d = 0.2
+    A = (0.1, -0.2, 0.3)
+    B = (0.0, 0.0, 1.1)
+    C = (0.2, -0.1, 0.3)
+    D = (0.4, 0.3, -0.2)
+
+    shells = [(1, 0, 0), (0, 1, 0), (0, 0, 1)]
+    block = primitive_eri_pppp_block_rys(a, A, b, B, c, C, d, D)
+    refs = np.zeros((3, 3, 3, 3), dtype=float)
+    for i, sh_a in enumerate(shells):
+        for j, sh_b in enumerate(shells):
+            for k, sh_c in enumerate(shells):
+                for l, sh_d in enumerate(shells):
+                    refs[i, j, k, l] = electron_repulsion(
+                        a, sh_a, A,
+                        b, sh_b, B,
+                        c, sh_c, C,
+                        d, sh_d, D,
+                    )
+    np.testing.assert_allclose(block, refs, atol=1e-12, rtol=1e-12)
+
+
+def test_contracted_ppps_rys_matches_existing_contracted_eri():
+    a = ContractedGaussian(
+        origin=[0.0, 0.1, -0.1],
+        shell=(1, 0, 0),
+        exps=[0.6, 0.2],
+        coefs=[0.7, 0.4],
+    )
+    b = ContractedGaussian(
+        origin=[0.0, 0.0, 1.4],
+        shell=(0, 0, 1),
+        exps=[0.5, 0.15],
+        coefs=[0.6, 0.3],
+    )
+    c = ContractedGaussian(
+        origin=[0.2, 0.1, -0.2],
+        shell=(0, 1, 0),
+        exps=[0.7, 0.25],
+        coefs=[0.5, 0.2],
+    )
+    d = ContractedGaussian(
+        origin=[-0.3, 0.2, 0.4],
+        shell=(0, 0, 0),
+        exps=[0.8, 0.3],
+        coefs=[0.4, 0.25],
+    )
+
+    ref = ERI(a, b, c, d)
+    val = contracted_eri_ppps_rys(a, b, c, d)
     np.testing.assert_allclose(val, ref, atol=1e-12, rtol=1e-12)
 
 


### PR DESCRIPTION
## Summary

- restore the second-order CASSCF batched derivative/sigma regression
- restore Rys roots, weights, symmetry, and integral reference coverage

This is the test-only focused replacement for the regression portion of #55.

## Validation

- `pytest -q tests/test_first_order_casscf.py::test_second_order_batched_derivative_sigma_matches_direct_loop tests/test_rys.py` — 20 passed
- `git diff --check` passes