### PR TITLE
feat: add hardened ODE and Krylov integration helpers

### DIFF
--- a/pyqed/integrate.py
+++ b/pyqed/integrate.py
@@ -1,0 +1,274 @@
+"""Small ODE integration helpers used across :mod:`pyqed`."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+from scipy import linalg as la
+from scipy.integrate import DOP853 as _ScipyDOP853
+from scipy.integrate import solve_ivp as _scipy_solve_ivp
+
+
+def normalize_method(method):
+    """Normalize common ODE method aliases to the names used internally."""
+    method_key = str(method).lower().replace("_", "-")
+    if method_key in ("adaptive", "dopri853"):
+        return "dop853"
+    if method_key in ("exp-krylov", "expm-krylov", "exponential-krylov"):
+        return "krylov"
+    return method_key
+
+
+def _validate_t_eval(t_eval):
+    t_eval = np.asarray(t_eval, dtype=np.float64)
+    if t_eval.ndim != 1 or t_eval.size == 0:
+        raise ValueError("t_eval must be a non-empty one-dimensional array")
+    if not np.all(np.isfinite(t_eval)):
+        raise ValueError("t_eval must contain only finite values")
+    if np.any(np.diff(t_eval) <= 0.0):
+        raise ValueError("t_eval must be strictly increasing")
+    return t_eval
+
+
+def dop853(rhs, y0, t_eval, rtol=1.0e-8, atol=1.0e-10,
+           observer=None, save=True, **options):
+    """Integrate with adaptive DOP853 and stream values onto ``t_eval``.
+
+    ``save=False`` retains only the final state and optional ``observer``
+    values.  This is the memory-efficient generic path for Python right-hand
+    sides; compiled solvers can implement the same result contract internally.
+    """
+    t_eval = _validate_t_eval(t_eval)
+    initial = np.asarray(y0)
+    dtype = np.complex128 if np.iscomplexobj(initial) else np.float64
+    y = np.ascontiguousarray(initial, dtype=dtype).reshape(-1)
+    if y.size == 0:
+        raise ValueError("y0 must contain at least one value")
+
+    states = [y.copy()] if save else None
+    observations = [observer(t_eval[0], y)] if observer is not None else None
+    if t_eval.size == 1:
+        return SimpleNamespace(
+            success=True,
+            message="success",
+            nfev=0,
+            n_steps=0,
+            t=t_eval.copy(),
+            y=np.asarray(states).T if save else None,
+            y_final=y.copy(),
+            observations=observations,
+        )
+
+    solver = _ScipyDOP853(
+        rhs,
+        float(t_eval[0]),
+        y,
+        float(t_eval[-1]),
+        rtol=rtol,
+        atol=atol,
+        **options,
+    )
+    output_index = 1
+    n_steps = 0
+
+    while solver.status == "running":
+        message = solver.step()
+        if solver.status == "failed":
+            return SimpleNamespace(
+                success=False,
+                message=message or "DOP853 failed",
+                nfev=solver.nfev,
+                n_steps=n_steps,
+                t=t_eval[:output_index].copy(),
+                y=np.asarray(states).T if save else None,
+                y_final=solver.y.copy(),
+                observations=observations,
+            )
+        n_steps += 1
+        tolerance = (
+            32.0 * np.finfo(float).eps * max(1.0, abs(float(solver.t)))
+        )
+        due_end = output_index
+        while due_end < t_eval.size and t_eval[due_end] <= solver.t + tolerance:
+            due_end += 1
+
+        dense_output = None
+        for index in range(output_index, due_end):
+            sample_t = t_eval[index]
+            if abs(sample_t - solver.t) <= tolerance:
+                sample = solver.y.copy()
+            else:
+                if dense_output is None:
+                    dense_output = solver.dense_output()
+                sample = np.asarray(dense_output(sample_t)).copy()
+            if save:
+                states.append(sample)
+            if observer is not None:
+                observations.append(observer(sample_t, sample))
+        output_index = due_end
+
+    if output_index != t_eval.size:
+        raise RuntimeError("DOP853 did not reach every requested output time")
+
+    return SimpleNamespace(
+        success=True,
+        message="success",
+        nfev=solver.nfev,
+        n_steps=n_steps,
+        t=t_eval.copy(),
+        y=np.asarray(states).T if save else None,
+        y_final=solver.y.copy(),
+        observations=observations,
+    )
+
+
+def solve_ivp(rhs, y0, t_eval, method="DOP853", rtol=1.0e-8,
+              atol=1.0e-10, observer=None, save=True, **options):
+    """Integrate ``dy/dt = rhs(t, y)`` on a requested output grid.
+
+    Krylov methods assume that ``rhs`` is a time-independent linear map.  The
+    adapter therefore evaluates ``rhs`` at the first requested time while
+    constructing each matrix-vector product.
+    """
+    t_eval = _validate_t_eval(t_eval)
+    method_key = normalize_method(method)
+    if method_key == "dop853":
+        return dop853(
+            rhs,
+            y0,
+            t_eval,
+            rtol=rtol,
+            atol=atol,
+            observer=observer,
+            save=save,
+            **options,
+        )
+    if method_key == "krylov":
+        initial_time = float(t_eval[0])
+        return krylov(
+            lambda y: rhs(initial_time, y),
+            y0,
+            t_eval,
+            observer=observer,
+            save=save,
+            **options,
+        )
+
+    y0 = np.asarray(y0)
+    if t_eval.size == 1:
+        y = y0.reshape(-1)
+        return SimpleNamespace(
+            success=True,
+            message="success",
+            nfev=0,
+            t=t_eval.copy(),
+            y=y.reshape(-1, 1).copy() if save else None,
+            y_final=y.copy(),
+            observations=[observer(t_eval[0], y)] if observer is not None else None,
+        )
+
+    solution = _scipy_solve_ivp(
+        rhs,
+        (float(t_eval[0]), float(t_eval[-1])),
+        y0,
+        method=method,
+        t_eval=t_eval,
+        rtol=rtol,
+        atol=atol,
+        **options,
+    )
+    solution.y_final = solution.y[:, -1].copy()
+    solution.observations = (
+        [observer(t, state) for t, state in zip(solution.t, solution.y.T)]
+        if observer is not None
+        else None
+    )
+    if not save:
+        solution.y = None
+    return solution
+
+
+def expm_krylov(matvec, y, dt, krylov_dim=30, tol=1.0e-12):
+    """Approximate ``exp(dt * A) @ y`` by Arnoldi using only ``A @ y``."""
+    y = np.asarray(y, dtype=np.complex128)
+    beta = np.linalg.norm(y)
+    if beta == 0:
+        return y.copy()
+
+    size = y.size
+    mmax = min(int(krylov_dim), size)
+    if mmax < 1:
+        raise ValueError("krylov_dim must be at least 1")
+
+    basis = np.zeros((mmax + 1, size), dtype=np.complex128)
+    hessenberg = np.zeros((mmax + 1, mmax), dtype=np.complex128)
+    basis[0] = y / beta
+    used_dim = mmax
+
+    for col in range(mmax):
+        work = matvec(basis[col])
+        for row in range(col + 1):
+            hessenberg[row, col] = np.vdot(basis[row], work)
+            work -= hessenberg[row, col] * basis[row]
+        next_norm = np.linalg.norm(work)
+        hessenberg[col + 1, col] = next_norm
+        if next_norm <= tol:
+            used_dim = col + 1
+            break
+        if col + 1 < mmax:
+            basis[col + 1] = work / next_norm
+
+    projected = hessenberg[:used_dim, :used_dim]
+    e1 = np.zeros(used_dim, dtype=np.complex128)
+    e1[0] = 1.0
+    coeff = la.expm(dt * projected) @ e1
+    return beta * (coeff @ basis[:used_dim])
+
+
+def krylov(matvec, y0, t_eval, krylov_dim=30, tol=1.0e-12,
+           observer=None, save=True, progress=None):
+    """Integrate a time-independent linear ODE with Krylov exponential steps."""
+    t_eval = _validate_t_eval(t_eval)
+
+    y = np.ascontiguousarray(np.asarray(y0, dtype=np.complex128).reshape(-1))
+    states = [y.copy()] if save else None
+    observations = [observer(t_eval[0], y)] if observer is not None else None
+
+    nfev = 0
+    steps = range(t_eval.size - 1)
+    if progress is not None:
+        steps = progress(steps)
+
+    for i in steps:
+        dt = t_eval[i + 1] - t_eval[i]
+        y = expm_krylov(matvec, y, dt, krylov_dim=krylov_dim, tol=tol)
+        nfev += min(int(krylov_dim), y.size)
+        if save:
+            states.append(y.copy())
+        if observer is not None:
+            observations.append(observer(t_eval[i + 1], y))
+
+    if save:
+        y_series = np.asarray(states, dtype=np.complex128).T
+    else:
+        y_series = None
+
+    return SimpleNamespace(
+        success=True,
+        message="success",
+        nfev=nfev,
+        t=t_eval.copy(),
+        y=y_series,
+        y_final=y.copy(),
+        observations=observations,
+    )
+
+
+__all__ = [
+    "dop853",
+    "expm_krylov",
+    "krylov",
+    "normalize_method",
+    "solve_ivp",
+]

--- a/tests/test_integrate.py
+++ b/tests/test_integrate.py
@@ -1,0 +1,122 @@
+import numpy as np
+import pytest
+from scipy import linalg as la
+
+from pyqed.integrate import (
+    dop853,
+    expm_krylov,
+    krylov,
+    normalize_method,
+    solve_ivp,
+)
+
+
+def test_normalize_method_aliases():
+    assert normalize_method("dopri853") == "dop853"
+    assert normalize_method("expm_krylov") == "krylov"
+    assert normalize_method("RK4") == "rk4"
+
+
+def test_expm_krylov_matches_dense_expm():
+    matrix = np.array([[0.0, -1.0], [1.0, 0.0]], dtype=np.complex128)
+    y0 = np.array([1.0, 0.0], dtype=np.complex128)
+
+    actual = expm_krylov(lambda y: matrix @ y, y0, 0.3, krylov_dim=2)
+    expected = la.expm(0.3 * matrix) @ y0
+
+    np.testing.assert_allclose(actual, expected, atol=1.0e-14)
+
+
+def test_krylov_matches_dense_exponential_on_grid():
+    matrix = np.array([[-0.2, 0.0], [0.0, -0.7]], dtype=np.complex128)
+    y0 = np.array([1.0, 2.0], dtype=np.complex128)
+    t_eval = np.linspace(0.0, 0.5, 6)
+
+    sol = krylov(lambda y: matrix @ y, y0, t_eval, krylov_dim=2)
+
+    expected = np.array([la.expm(t * matrix) @ y0 for t in t_eval]).T
+    assert sol.success
+    np.testing.assert_allclose(sol.y, expected, atol=1.0e-14)
+
+
+@pytest.mark.parametrize(
+    "method",
+    ["krylov", "exp_krylov", "expm-krylov", "exponential_krylov"],
+)
+def test_solve_ivp_krylov_aliases_match_direct_krylov(method):
+    matrix = np.array([[-0.2, 0.1], [-0.3, -0.7]], dtype=np.complex128)
+    y0 = np.array([1.0, 2.0], dtype=np.complex128)
+    t_eval = np.linspace(0.25, 0.75, 6)
+    rhs_times = []
+
+    def rhs(t, y):
+        rhs_times.append(t)
+        return matrix @ y
+
+    actual = solve_ivp(
+        rhs,
+        y0,
+        t_eval,
+        method=method,
+        krylov_dim=2,
+    )
+    expected = krylov(lambda y: matrix @ y, y0, t_eval, krylov_dim=2)
+
+    assert actual.success
+    np.testing.assert_allclose(actual.y, expected.y, atol=1.0e-14)
+    assert rhs_times
+    assert set(rhs_times) == {t_eval[0]}
+
+
+@pytest.mark.parametrize(
+    "t_eval, message",
+    [
+        ([0.0, 0.0, 1.0], "strictly increasing"),
+        ([0.0, 1.0, 0.5], "strictly increasing"),
+        ([0.0, np.nan, 1.0], "finite"),
+        ([0.0, np.inf, 1.0], "finite"),
+    ],
+    ids=["duplicate", "decreasing", "nan", "infinity"],
+)
+def test_krylov_rejects_invalid_t_eval(t_eval, message):
+    with pytest.raises(ValueError, match=message):
+        krylov(lambda y: y, [1.0], t_eval)
+
+
+def test_solve_ivp_dop853_exponential_decay():
+    t_eval = np.linspace(0.0, 1.0, 6)
+    y0 = np.array([1.0 + 0.0j])
+
+    sol = solve_ivp(
+        lambda _t, y: -0.5 * y,
+        y0,
+        t_eval,
+        method="DOP853",
+        rtol=1.0e-11,
+        atol=1.0e-13,
+    )
+
+    assert sol.success
+    assert sol.n_steps > 0
+    np.testing.assert_allclose(sol.y[0], np.exp(-0.5 * t_eval), atol=1.0e-11)
+
+
+def test_dop853_streams_observations_without_saving_states():
+    t_eval = np.linspace(0.0, 2.0, 21)
+    y0 = np.array([1.0 + 0.0j])
+
+    sol = dop853(
+        lambda _t, y: -0.5 * y,
+        y0,
+        t_eval,
+        rtol=1.0e-11,
+        atol=1.0e-13,
+        observer=lambda _t, y: y[0],
+        save=False,
+    )
+
+    assert sol.success
+    assert sol.y is None
+    assert sol.n_steps > 0
+    np.testing.assert_allclose(sol.observations, np.exp(-0.5 * t_eval), atol=1.0e-11)
+    np.testing.assert_allclose(sol.y_final, [np.exp(-1.0)], atol=1.0e-11)


### PR DESCRIPTION
## Summary

- add a common `solve_ivp` wrapper and streaming DOP853 helper
- add matrix-free exponential Krylov propagation
- support normalized Krylov method aliases through `solve_ivp`
- strictly validate output grids, including duplicate, decreasing, and non-finite values
- document that Krylov mode assumes a time-independent linear RHS

This is a hardened, focused replacement for the integration portion of #55.

## Validation

- `pytest -q tests/test_integrate.py` — 13 passed
- `git diff --check` passes

## Draft note

Kept as a draft until an initial production caller or user-facing API example is selected.