### PR TITLE
docs: build a structured PyQED user guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,61 +1,28 @@
-# Welcome to LIght-Matter Everything!
+# PyQED documentation
 
-The ultimate goal is to provide a simple-to-use package to study how light interacts with matter.  
+The public user guide is built from the reStructuredText sources in
+`docs/source/` with Sphinx. Read the Docs uses `.readthedocs.yaml` and
+`docs/requirements.txt` from the repository root.
 
-Check manual.pdf for documentation! 
+Build the same strict HTML documentation locally from the repository root:
 
-Main modules
+```bash
+python -m pip install -r docs/requirements.txt
+python -m sphinx -W --keep-going -b html docs/source /tmp/pyqed-docs
+```
 
-# Nonlinear molecular spectroscopy 
-* sum-of-states for multilevel system
+Open `/tmp/pyqed-docs/index.html` after the build succeeds.
 
-Pros: computationally cheap 
-Cons: decay is introduced phenomelogically; pure dephasing cannot be addressed 
+Documentation principles:
 
-* correlation function approach --  Direct computing the many-point correlation functions with the quantum regression theorem 
+- Keep one canonical page for each method and link to it from the guide hub.
+- Put a minimal runnable example and expected result near the top of a method
+  page.
+- State units, convergence controls, limitations, maturity, and optional
+  dependencies explicitly.
+- Use `literalinclude` for tracked examples when practical so code on the web
+  stays synchronized with executable files.
+- Run the strict Sphinx command above before submitting documentation changes.
 
-
-Valid for open quantum systems where environment effects can be rigirously described with open quantum system techniques. 
-
-Visulize with double-sided Feynman diagrams instead of the time-loop diagrams. 
-
-
-* non-perturbative approah -- valid for ALL systems provided the quantum dynamics can be compuated 
-
-Simulating the laser-driven dynamics including explicitly all laser pulses    
-
-# Molecular quantum dynamics 
-- Wavepacket dynamics 
--- Split-operator method 
-
-- Nonadiabatic dynamics 
-- Split-operator method 
-
-For the exact nonadiabatic dynamics of vibronic models in the diabatic representation. 
-
-# Semiclassical quantum trajectory method 
-
-# Quantum chemistry 
-
-# Open quantum systems 
-- Lindblad quantum master equation
-- Redfield theory  
-- second-order time-convolutionless master equation 
-- hierarchical equation of motion 
-
-# Quantum transport 
-- Landauer transport 
-
-# Soid state materials 
-- Band structure from tight-binding Hamiltonians 
-
-# Periodically driven matter 
-- Floquet spectrum 
-
-# Others 
-- Schmidt decomposition 
-
-
-
-
-
+The project overview at `pyqed.org` should remain concise; detailed scientific
+guidance belongs here and is published at `docs.pyqed.org`.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,6 @@
-Sphinx>=7.3,<9
-sphinx-rtd-theme>=2.0
+Sphinx>=8,<9
+pydata-sphinx-theme>=0.16,<0.20
+sphinx-copybutton>=0.5
 roman>=4.1
 
 numpy>=2.0

--- a/docs/source/capabilities.rst
+++ b/docs/source/capabilities.rst
@@ -48,7 +48,7 @@ Current development-branch matrix
      - Beta
      - :doc:`dvr`
      - ``tests/test_fedvr.py``, ``tests/test_sddvr.py``,
-       ``examples/dvr/fedvr_harmonic_oscillator.py``
+       ``examples/dvr/sine_harmonic_oscillator.py``
    * - Basic superoperators and Lindblad utilities
      - Experimental
      - :doc:`guide/guide_open_dynamics`
@@ -61,7 +61,7 @@ Current development-branch matrix
    * - HEOM and structured-bath workflows
      - Experimental
      - :doc:`heom`
-     - ``examples/heom.py`` and repository examples
+     - ``examples/heom_compact.py``, ``examples/heom.py``
    * - Molecular GW/BSE
      - Experimental
      - :doc:`gw_bse`

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -46,7 +46,12 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx.ext.mathjax',
     'sphinx.ext.viewcode',
+    'sphinx_copybutton',
 ]
+
+# Copy runnable commands without their shell or interpreter prompts.
+copybutton_prompt_text = r'>>> |\.\.\. |\$ '
+copybutton_prompt_is_regexp = True
 
 #.. autoclass:: lime.oqs.LindbladSolver
 
@@ -93,7 +98,30 @@ autodoc_mock_imports = [
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
+html_theme = 'pydata_sphinx_theme'
+html_title = 'PyQED User Guide'
+html_context = {
+    'default_mode': 'auto',
+}
+html_theme_options = {
+    'show_nav_level': 2,
+    'navigation_depth': 4,
+    'show_toc_level': 2,
+    'show_prev_next': True,
+    'navigation_with_keys': True,
+    'search_bar_text': 'Search the PyQED guide...',
+    'navbar_align': 'content',
+    'header_links_before_dropdown': 6,
+    'secondary_sidebar_items': ['page-toc', 'sourcelink'],
+    'icon_links': [
+        {
+            'name': 'GitHub',
+            'url': 'https://github.com/binggu56/pyqed',
+            'icon': 'fa-brands fa-square-github',
+            'type': 'fontawesome',
+        },
+    ],
+}
 
 # Consolidate Read the Docs aliases and historical versions around the public
 # documentation domain. Sphinx emits a per-page canonical link from this base.

--- a/docs/source/dvr.rst
+++ b/docs/source/dvr.rst
@@ -1,60 +1,136 @@
 Discrete Variable Representation
 ================================
 
-PyQED includes several discrete variable representation (DVR) utilities for
-grid-based quantum dynamics and model Hamiltonians. DVR methods represent
-wavefunctions on quadrature or collocation grids while keeping derivative and
-kinetic-energy operators as compact matrices.
+Discrete variable representations (DVRs) describe a wavefunction by its
+values on a grid.  They are especially convenient when the potential is local:
+the potential-energy operator is diagonal, while PyQED supplies the
+representation-specific kinetic-energy matrix.
 
-Available Modules
+When to use a DVR
 -----------------
 
-The DVR code lives under ``pyqed.dvr``:
+Use a DVR for low-dimensional nuclear or model-coordinate problems when you
+want to:
 
-* ``pyqed.dvr.dvr_1d`` provides one-dimensional DVR utilities.
-* ``pyqed.dvr.dvr_2d`` provides multidimensional tensor-product DVR utilities.
-* ``pyqed.dvr.sddvr`` implements simultaneous-diagonalization DVR helpers.
-* ``pyqed.dvr.gwp_fbr`` contains Gaussian-wavepacket finite-basis tools for
-  SD-DVR.
-* ``pyqed.dvr.gauss_hermite`` contains legacy Gauss-Hermite DVR routines.
+* solve a one- or few-dimensional Schrödinger equation on a finite domain;
+* apply a potential directly as values evaluated on a grid;
+* inspect wavefunctions in coordinate space; or
+* construct a grid Hamiltonian for later propagation or coupling to another
+  model.
 
-Typical Workflow
-----------------
+The sine DVR used below is a good default for a bounded, non-periodic
+coordinate whose wavefunction is negligible at both ends of the interval.  A
+periodic coordinate, a singular radial problem, or a large multidimensional
+calculation may require a different representation.
 
-A DVR calculation usually follows this pattern:
+Minimal example: harmonic oscillator
+------------------------------------
 
-1. Choose a coordinate domain and grid size.
-2. Build the kinetic-energy operator for the chosen DVR basis.
-3. Evaluate the potential on the DVR grid.
-4. Assemble the Hamiltonian ``H = T + V``.
-5. Diagonalize or propagate the wavefunction.
+This example constructs
 
-Example
--------
+.. math::
 
-The one-dimensional utilities can be used to assemble a simple grid
-Hamiltonian. The exact class/function names depend on the DVR module selected,
-but the calculation structure is:
+   H = -\frac{1}{2m}\frac{d^2}{dx^2} + \frac{x^2}{2}
 
-.. code-block:: python
+in atomic units.  ``SineDVR`` provides the interior grid ``dvr.x`` and the
+kinetic-energy matrix ``dvr.t()``; a local potential is added as a diagonal
+matrix.
 
-   import numpy as np
+.. literalinclude:: ../../examples/dvr/sine_harmonic_oscillator.py
+   :language: python
+   :linenos:
 
-   from pyqed.dvr.dvr_1d import kinetic
+Expected result
+~~~~~~~~~~~~~~~
 
-   x = np.linspace(-8.0, 8.0, 256)
-   mass = 1.0
+.. code-block:: text
 
-   T = kinetic(x, mass=mass, dvr="sinc")
-   V = np.diag(0.5 * x**2)
-   H = T + V
+   [0.5 1.5 2.5 3.5]
 
-   energies, states = np.linalg.eigh(H)
-   print(energies[:5])
+These are the first four analytic harmonic-oscillator energies,
+:math:`E_n=n+1/2`.  Agreement here checks both the box and grid for these
+low-lying states; it does not by itself establish convergence for higher
+states or a different potential.
 
-Notes
------
+Important parameters
+--------------------
 
-This page is intentionally written as a static guide rather than an autodoc API
-page. Some legacy DVR modules import optional dependencies or run example code
-at import time, which is not suitable for warning-free Read the Docs builds.
+``xmin``, ``xmax``
+   Endpoints of the finite box.  Sine-basis functions vanish at the
+   endpoints, and the ``npts`` coordinates lie strictly inside the box.
+
+``npts``
+   Number of sine basis functions and interior DVR points.  Increasing it
+   improves spatial resolution but makes the dense matrices larger.
+
+``mass``
+   Mass used by the kinetic-energy operator.  It defaults to ``1``.  The mass,
+   coordinate, potential, and requested energies must all use one consistent
+   unit system.
+
+``dvr.x``
+   The coordinate values at which a local potential is evaluated.
+
+``dvr.t()``
+   The analytic sine-DVR kinetic-energy matrix.  Assemble a one-dimensional
+   local Hamiltonian as ``dvr.t() + np.diag(V(dvr.x))``.
+
+How the sine DVR works
+----------------------
+
+On a box of length :math:`L=x_{\max}-x_{\min}`, the finite-basis
+representation consists of sine functions that satisfy zero boundary
+conditions.  PyQED transforms this basis to the equally spaced interior
+collocation points
+
+.. math::
+
+   x_\alpha = x_{\min} + \frac{\alpha L}{N+1},
+   \qquad \alpha=1,\ldots,N.
+
+The potential is diagonal at these points.  The kinetic operator is not
+diagonal in the DVR, but its matrix elements are known analytically.  The
+result is a straightforward dense eigenvalue problem for small grids and a
+convenient Hamiltonian representation for time propagation.
+
+Convergence and limitations
+---------------------------
+
+Converge a reported result with respect to both the box and ``npts``:
+
+1. Enlarge ``xmin`` and ``xmax`` until the states of interest are negligible
+   near both boundaries.
+2. Increase ``npts`` until energies and observables stop changing at the
+   required precision.
+3. Check normalization and boundary behavior of the corresponding
+   eigenvectors, not only their eigenvalues.
+
+The standard sine-DVR matrices are dense, requiring :math:`O(N^2)` storage;
+full dense diagonalization costs :math:`O(N^3)`.  Tensor-product grids grow
+exponentially with the number of coordinates.  Discontinuous potentials,
+continuum states, periodic coordinates, and coordinate singularities also
+need special care or a more suitable representation.
+
+Other DVR implementations
+-------------------------
+
+The :mod:`pyqed.dvr` namespace also contains sinc, finite-element,
+Gauss--Hermite, simultaneous-diagonalization, and multidimensional DVR tools.
+Their grids, boundary conditions, and numerical tradeoffs differ, so do not
+change the DVR family without repeating the convergence checks.
+
+API, source, and related material
+---------------------------------
+
+* API namespace: :mod:`pyqed.dvr`; ``SineDVR`` is implemented in
+  :mod:`pyqed.dvr.dvr_1d`.
+* `SineDVR source (PyQED 0.2.0)
+  <https://github.com/binggu56/pyqed/blob/v0.2.0/pyqed/dvr/dvr_1d.py>`__
+* `Runnable harmonic-oscillator example
+  <https://github.com/binggu56/pyqed/blob/main/examples/dvr/sine_harmonic_oscillator.py>`__
+* `Sine-DVR/FEDVR comparison example (PyQED 0.2.0)
+  <https://github.com/binggu56/pyqed/blob/v0.2.0/examples/dvr/fedvr_vs_sine_quartic.py>`__
+* :doc:`tutorials` for the recommended learning path
+* :doc:`examples` for additional grid calculations
+* :doc:`pyqed.namd` and :doc:`geometric_quantum_dynamics` for dynamics built on
+  coordinate-space representations

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -1,122 +1,160 @@
-Examples Gallery
+Examples gallery
 ================
 
-The repository includes runnable entry points under ``examples/``. This page
-groups useful starting points by topic. Some are small smoke cases, while
-others are expensive research workflows with external dependencies and cached
-data. A listing here does not promote a workflow beyond the maturity shown in
-:doc:`capabilities`.
+The repository contains many scripts under ``examples/``.  This page puts the
+smallest maintained entry points first and labels larger files as research
+workflows.  A filename in the inventory does not imply that every option is
+validated; consult :doc:`capabilities` before using a result as evidence.
 
-Run an example from the repository root and inspect its imports, parameters,
-and output paths before execution. For research use, preserve the exact script
-commit and a :doc:`benchmarks` manifest.
+Run source-tree examples from the repository root with ``PYTHONPATH=.``.  The
+code shown here is included directly from the tracked files, so the web guide
+and executable examples stay synchronized.
 
-Quantum Chemistry
------------------
+Three verified starting points
+------------------------------
 
-* ``examples/qchem/sa_casscf_factor.py``: native factorized,
-  state-averaged CASSCF on a small H4 model.
-* ``examples/qchem/gw_qsgw.py``: native H2 RHF followed by small GW-family
-  workflows.
-* ``examples/qchem/casscf.py``: native CASSCF workflow.
-* ``examples/qchem/casscf_factor_vs_dense.py``: compare dense and factorized
-  CASSCF paths.
-* ``examples/qchem/comp2_h2o.py``: COMP2 example on water.
-* ``examples/qchem/gw_qsgw.py``: G0W0, eigenvalue-self-consistent GW, and qsGW
-  on H2.
-* ``examples/qchem/rttdhf_h2_kick_spectrum.py``: real-time TDHF kick spectrum
-  for H2.
-* ``examples/qchem/tddmrg_h2_threeway_compare.py``: time-dependent DMRG
-  comparison example.
+Native H2 restricted Hartree--Fock
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Multiconfigurational Methods
-----------------------------
+**Use for:** checking an installation and learning the molecular
+model--build--solve pattern.  **Requirements:** the base PyQED installation.
+**Typical runtime:** less than a minute on a laptop.
 
-* ``examples/qchem/mcscf/secondorder_casscf.py``: second-order CASSCF example.
-* ``examples/qchem/mcscf/cas_pyscf.py``: CAS comparison workflow.
-* ``examples/qchem/mcscf/wfn_overlap.py``: wavefunction overlap example.
-* ``examples/qchem/lif_casscf_scan.py``: LiF CASSCF scan.
-* ``examples/qchem/casscf_compare_vs_pyscf.py``: CASSCF comparison against
-  PySCF.
+.. literalinclude:: ../../examples/quickstart.py
+   :language: python
+   :linenos:
 
-DVR and Grid Dynamics
----------------------
-
-* ``examples/dvr/sddvr.py``: simultaneous-diagonalization DVR.
-* ``examples/dvr/gwp_sddvr_2d_independent_ho.py``: Gaussian-wavepacket SD-DVR
-  on a two-dimensional harmonic oscillator.
-* ``examples/dvr/shin_metiu.py``: Shin-Metiu DVR model.
-* ``examples/qchem/gdvr_h2_rhf.py``: grid-DVR RHF example for H2.
-* ``examples/qchem/gdvr_h4_rhf.py``: grid-DVR RHF example for H4.
-
-Nonadiabatic Dynamics
----------------------
-
-* ``examples/namd/ehrenfest.py``: Ehrenfest dynamics.
-* ``examples/namd/ehrenfest_histories.py``: trajectory/history handling.
-* ``examples/namd/abinitio_ehrenfest_pyscf.py``: ab initio Ehrenfest workflow
-  using PySCF as a backend.
-* ``examples/namd/lif_population_dynamics.py``: LiF population dynamics.
-
-Geometric Quantum Dynamics
---------------------------
-
-* ``examples/ldr/ldr.py``: locally diabatic representation dynamics.
-* ``examples/ldr/abinitio.py``: ab initio LDR workflow.
-* ``examples/ldr/abinitio_pyscf.py``: PySCF-backed ab initio LDR workflow.
-* ``examples/ldr/overlap_matrix_approximation_2D.py``: approximate electronic
-  overlap matrices on a two-dimensional grid.
-* ``examples/ldr/h3/1scan_PES_H3+.py``: H3+ adiabatic potential scan.
-* ``examples/ldr/h3/2calculate_overlap_nearest_neighbor.py``: nearest-neighbor
-  electronic-state overlaps.
-* ``examples/qchem/bo_hamiltonian_derivatives.py``: BO Hamiltonian derivative
-  construction.
-* ``examples/qchem/bo_hamiltonian_derivatives_normal_modes.py``: BO derivative
-  projection onto normal modes.
-
-Floquet and Light-Matter Models
--------------------------------
-
-* ``examples/floquet/two_level_system.py``: driven two-level model.
-* ``examples/floquet/RiceMele.py``: Rice-Mele model.
-* ``examples/floquet/Floquet_topological_phase_diagram.py``: Floquet phase
-  diagram example.
-* ``examples/test_cavity.py``: cavity-QED smoke example.
-
-Open Quantum Systems and Spectroscopy
--------------------------------------
-
-* ``examples/heom.py``: hierarchical equations of motion example.
-* ``examples/deom.py``: dissipaton equation of motion example.
-* ``examples/redfield.py``: Redfield dynamics example.
-* ``examples/signals/absorption.py``: absorption signal example.
-* ``examples/2DES.py``: two-dimensional electronic spectroscopy example.
-* ``examples/TPA.py``: two-photon absorption example.
-
-Running Examples
-----------------
-
-Run examples from the repository root so relative data files resolve correctly:
+Run it with:
 
 .. code-block:: bash
 
-   PYTHONPATH=. python examples/qchem/sa_casscf_factor.py
-   PYTHONPATH=. python examples/dvr/fedvr_harmonic_oscillator.py
+   PYTHONPATH=. python examples/quickstart.py
 
-Some examples require optional dependencies or compiled backends. If an example
-imports PySCF, PyVista, libxc, or plotting packages, install those dependencies
-separately before running it.
+The final line is approximately ``RHF energy: -1.116759307396 Eh``.  See
+:doc:`quickstart` for the explanation and :doc:`qchem` before changing the
+molecule or electronic-structure method.
 
-``examples/qchem/h2.py`` is a PySCF-based potential-curve script despite its
-generic filename; it is not the native PyQED quickstart. Use
-:doc:`quickstart` for the tested native entry path.
+Sine-DVR harmonic oscillator
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Related Pages
--------------
+**Use for:** learning grid construction, local potentials, and a known
+analytic spectrum.  **Requirements:** the base PyQED installation.
+**Typical runtime:** a few seconds.
 
-* :doc:`hf_analysis`
-* :doc:`mp2_comp2`
-* :doc:`gw_bse`
-* :doc:`tddft_ehrenfest`
-* :doc:`geometric_quantum_dynamics`
-* :doc:`guide/guide_qchem_mcscf`
+.. literalinclude:: ../../examples/dvr/sine_harmonic_oscillator.py
+   :language: python
+   :linenos:
+
+Run it with:
+
+.. code-block:: bash
+
+   PYTHONPATH=. python examples/dvr/sine_harmonic_oscillator.py
+
+Expected output is ``[0.5 1.5 2.5 3.5]``.  The :doc:`dvr` guide explains why
+both the box and number of points must be converged for a new potential.
+
+Compact HEOM spin--boson dynamics
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Use for:** exercising the current one-exponential Drude--Lorentz HEOM path.
+**Requirements:** the base installation for this compact solver; the
+``pyqed[heom]`` extra is needed for separate DEOM/structured-bath helpers.
+**Typical runtime:** less than a minute.
+
+.. literalinclude:: ../../examples/heom_compact.py
+   :language: python
+   :linenos:
+
+Run it with:
+
+.. code-block:: bash
+
+   PYTHONPATH=. python examples/heom_compact.py
+
+The final line is ``Final <sigma_z>: -0.96907844``.  Read :doc:`heom` before
+interpreting the parameter called ``temperature`` or changing the time step,
+bath decomposition, or hierarchy depth.
+
+Choose a larger workflow
+------------------------
+
+The scripts below are useful next destinations, but many have optional
+dependencies, longer runtimes, model-specific inputs, or research interfaces.
+Inspect their imports, parameters, data files, and output paths before running
+them.
+
+Quantum chemistry
+~~~~~~~~~~~~~~~~~
+
+* ``examples/qchem/sa_casscf_factor.py`` -- native factorized,
+  state-averaged CASSCF on a small H4 model.
+* ``examples/qchem/casscf_factor_vs_dense.py`` -- compare dense and factorized
+  CASSCF paths.
+* ``examples/qchem/comp2_h2o.py`` -- COMP2 on water.
+* ``examples/qchem/gw_qsgw.py`` -- G0W0, eigenvalue-self-consistent GW, and
+  qsGW on H2.
+* ``examples/qchem/rttdhf_h2_kick_spectrum.py`` -- real-time TDHF kick
+  spectrum for H2.
+
+Read :doc:`qchem`, :doc:`backends`, and the relevant method page before
+scaling these calculations.
+
+Grid and nonadiabatic dynamics
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* ``examples/dvr/fedvr_vs_sine_quartic.py`` -- compare two grid
+  representations for a quartic potential.
+* ``examples/dvr/gwp_sddvr_2d_independent_ho.py`` -- Gaussian-wavepacket
+  SD-DVR for a two-dimensional oscillator.
+* ``examples/dvr/shin_metiu.py`` -- an early Shin--Metiu research script; it
+  is not maintained as a first-run example, so inspect and adapt it rather
+  than expecting a turnkey smoke test.
+* ``examples/namd/ehrenfest.py`` -- model Ehrenfest dynamics.
+* ``examples/namd/ldrfg_avoided_crossing.py`` -- an avoided-crossing LDRFG
+  workflow.
+* ``examples/namd/abinitio_ehrenfest_pyscf.py`` -- an ab initio workflow with
+  an optional PySCF backend.
+
+Continue with :doc:`geometric_quantum_dynamics` and :doc:`pyqed.namd`.
+
+Open systems and spectroscopy
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* ``examples/heom.py`` -- the longer historical HEOM exploration script.
+* ``examples/deom.py`` -- a dissipaton-equation-of-motion research workflow.
+* ``examples/redfield.py`` -- Redfield dynamics.
+* ``examples/signals/absorption.py`` -- an absorption-signal calculation.
+* ``examples/2DES.py`` -- a larger two-dimensional spectroscopy workflow.
+
+See :doc:`guide/guide_open_dynamics`, :doc:`heom`, and
+:doc:`guide/guide_spectroscopy` for the governing assumptions.
+
+Floquet, light--matter, and tensor networks
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* ``examples/floquet/two_level_system.py`` -- a driven two-level model.
+* ``examples/floquet/RiceMele.py`` -- a Rice--Mele model.
+* ``examples/floquet/Floquet_topological_phase_diagram.py`` -- a phase-diagram
+  workflow.
+* ``examples/test_cavity.py`` -- a cavity-QED smoke script.
+* ``examples/qchem/tddmrg_h2_threeway_compare.py`` -- a time-dependent DMRG
+  comparison.
+
+Read :doc:`pyqed.floquet`, :doc:`pyqed.polariton`, and :doc:`mps` before
+adapting them.
+
+Turn an example into evidence
+-----------------------------
+
+Before publishing a result derived from an example:
+
+* pin the PyQED release or full Git commit and record whether the tree changed;
+* preserve the exact input, random seed, units, basis or grid, backend, and
+  solver tolerances;
+* establish convergence with respect to every relevant numerical control;
+* compare a small case with an analytic or independent reference; and
+* use the :doc:`benchmarks` manifest for validation or performance claims.
+
+If an example fails, report the smallest reproducible command using the
+:doc:`support` checklist.

--- a/docs/source/guide/core_workflow.rst
+++ b/docs/source/guide/core_workflow.rst
@@ -1,0 +1,178 @@
+.. _core-workflow:
+
+.. meta::
+   :description: Learn the common PyQED workflow from physical model and numerical representation to solver diagnostics, validation, and reproducible results.
+
+How PyQED calculations work
+===========================
+
+PyQED spans several method families, but a reliable calculation usually has
+the same lifecycle:
+
+#. define the physical question and units;
+#. choose a model and numerical representation;
+#. build the numerical data required by that representation;
+#. configure and run a solver;
+#. inspect convergence and physical diagnostics; and
+#. repeat at tighter numerical settings and validate against an independent
+   result before drawing a scientific conclusion.
+
+The exact object names differ between quantum chemistry, grid dynamics, open
+systems, spectroscopy, and tensor networks.  This page describes the shared
+workflow; each method guide documents its own inputs and limitations.
+
+A minimal calculation
+---------------------
+
+This native H2 restricted Hartree--Fock calculation shows the common
+model--build--solve pattern:
+
+.. code-block:: python
+
+   from pyqed.qchem import Molecule
+
+   mol = Molecule(
+       atom="H 0 0 0; H 0 0 0.74",
+       unit="angstrom",
+       basis="sto-3g",
+   )
+   mol.build(driver="builtin", eri="auto")
+
+   mf = mol.RHF().run()
+   print("converged:", mf.converged)
+   print("RHF energy (Hartree):", f"{mf.e_tot:.8f}")
+
+Run it in an installed environment, or from a source checkout with
+``PYTHONPATH=.``.  The expected output is approximately:
+
+.. code-block:: text
+
+   converged: True
+   RHF energy (Hartree): -1.11675931
+
+Small last-digit differences can occur across numerical libraries.  The
+important first checks are that the solver reports convergence and that the
+energy is finite.  The :doc:`complete quickstart </quickstart>` explains each
+line and shows how the converged reference feeds MP2 and CASSCF calculations.
+
+Model, build, solve, inspect
+----------------------------
+
+**Model**
+   Record the scientific inputs explicitly: geometry or Hamiltonian,
+   coordinate units, basis or grid, charge and spin, bath or pulse parameters,
+   initial state, and boundary conditions.  Defaults are convenient for
+   exploration but should not be implicit in a published calculation.
+
+**Build**
+   Convert the physical description into a numerical representation.  In the
+   example, ``mol.build(...)`` constructs molecular integrals and
+   ``eri="auto"`` selects a supported electron-repulsion representation.  In
+   other areas this step may construct a DVR kinetic operator, a Liouvillian,
+   an HEOM hierarchy, or an MPO.
+
+**Solve**
+   Create the method object, set convergence controls deliberately, and run
+   it.  PyQED drivers commonly retain their outputs on the solver object after
+   ``run()``; field names differ by method, so follow the method page rather
+   than assuming that every solver exposes ``e_tot`` or ``converged``.
+
+**Inspect**
+   Do not treat the main scalar result as sufficient evidence.  Check the
+   method-specific convergence flag or residual, normalization and conserved
+   quantities, state ordering, symmetry labels, and any warning messages.
+
+Choose a representation before a method
+---------------------------------------
+
+The representation often controls both the physical approximation and the
+computational cost.
+
+.. list-table:: Starting points by task
+   :header-rows: 1
+   :widths: 25 38 37
+
+   * - Task
+     - Representation choices
+     - Read next
+   * - Molecular electronic structure
+     - Atomic-orbital basis; dense, packed, RI, or factorized integrals
+     - :doc:`Quantum chemistry </qchem>` and :doc:`backends </backends>`
+   * - Grid quantum dynamics
+     - Coordinate domain, DVR family, grid size, and boundary conditions
+     - :doc:`Discrete variable representations </dvr>`
+   * - Nonadiabatic dynamics
+     - Adiabatic, diabatic, locally diabatic, or geometric representation
+     - :doc:`Geometric dynamics </geometric_quantum_dynamics>` and
+       :doc:`NAMD API </pyqed.namd>`
+   * - Open-system dynamics
+     - Density matrix, Liouville space, bath decomposition, and hierarchy
+     - :doc:`Open dynamics <guide_open_dynamics>` and :doc:`HEOM </heom>`
+   * - Tensor-network calculations
+     - Site ordering, local basis, MPO, bond dimension, and symmetry sectors
+     - :doc:`Matrix product states </mps>`
+
+Convergence and validation
+--------------------------
+
+A completed call to ``run()`` is not by itself a validated calculation.  Vary
+the controls that define the numerical approximation:
+
+* basis size, active space, integral threshold, or auxiliary basis;
+* grid spacing, coordinate range, and time step;
+* hierarchy depth and bath decomposition;
+* bond dimension, truncation tolerance, and sweep count; or
+* number of states, propagation time, and frequency resolution.
+
+Converge the observable of interest, not only the total energy or norm.  Then
+compare a small case with an analytic limit, an independently implemented
+algorithm, or a documented external reference.  :doc:`Benchmarks and
+validation </benchmarks>` defines the distinction between a regression test,
+independent validation, and a performance result.
+
+Know the limits of the selected path
+------------------------------------
+
+PyQED combines Beta workflows with rapidly changing research implementations.
+Optional dependencies, supported state or spin sectors, storage
+representations, and available diagnostics vary by method.  Before scaling a
+calculation:
+
+* check the :doc:`capability matrix </capabilities>`;
+* run the smallest tracked example for the exact solver path;
+* read the method page for its assumptions and unsupported combinations; and
+* confirm that the chosen backend exposes the data required by downstream
+  methods.
+
+Record a reproducible result
+----------------------------
+
+Preserve enough information to reconstruct both the physical problem and the
+software environment:
+
+* PyQED release or full Git commit, including whether the tree was modified;
+* Python and dependency versions, platform, and numerical libraries;
+* complete input, units, random seeds, backend, and solver tolerances;
+* thread settings and hardware for performance results; and
+* raw output plus the convergence and validation evidence used to accept it.
+
+For a source checkout, a controlled serial baseline can be run as:
+
+.. code-block:: bash
+
+   OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 \
+   VECLIB_MAXIMUM_THREADS=1 NUMEXPR_NUM_THREADS=1 \
+   PYTHONPATH=. python examples/quickstart.py
+
+Use the :doc:`benchmark manifest </benchmarks>` for quantitative validation
+or performance claims, and :doc:`cite the exact software artifact and method
+</citing>` in published work.
+
+Where to go next
+----------------
+
+Return to the :doc:`user-guide topic map <guide>`, follow a structured path in
+:doc:`tutorials </tutorials>`, or start from a maintained script in the
+:doc:`examples index </examples>`.  If a documented example fails, reduce the
+problem to that smallest case and follow the :doc:`support checklist
+</support>`.

--- a/docs/source/guide/guide.rst
+++ b/docs/source/guide/guide.rst
@@ -1,13 +1,169 @@
 .. _guide:
 
-***********
-User guides
-***********
+.. meta::
+   :description: Task-oriented PyQED user guide for quantum chemistry, quantum dynamics, open systems, spectroscopy, and tensor networks.
+
+PyQED user guide
+================
+
+The user guide organizes PyQED by scientific task.  It reuses the canonical
+method, example, and API pages rather than repeating their content.  Choose a
+topic below, run its smallest example first, and check the stated maturity and
+limitations before adapting it to a research calculation.
+
+.. important::
+
+   PyQED is active research software.  A module being importable does not mean
+   every option is supported or validated.  Consult the :doc:`capability
+   matrix </capabilities>` and the limitations on the relevant method page.
+
+New to PyQED?
+-------------
+
+#. :doc:`Install PyQED </installation>` in an isolated environment.
+#. Run the :doc:`five-minute H2 quickstart </quickstart>`.
+#. Read :doc:`How PyQED calculations work <core_workflow>` for the common
+   model--build--solve--validate workflow.
+#. Pick a task-oriented path in :doc:`Tutorials and learning paths
+   </tutorials>` or browse the :doc:`runnable examples index </examples>`.
+
+Foundations and common workflow
+-------------------------------
+
+* :doc:`How PyQED calculations work <core_workflow>` explains how inputs,
+  numerical representations, solver objects, diagnostics, and validation fit
+  together.
+* :doc:`Theory overview </theory>` introduces the Hamiltonian, wavefunction,
+  density-matrix, response, and representation conventions shared across
+  method areas.
+* :doc:`Backends and integral representations </backends>` describes native,
+  dense, packed, RI, and factorized electronic-structure paths.
+* :doc:`API entry points </api>` maps supported workflows to their modules;
+  it is a navigation aid rather than a blanket stability promise.
+
+Electronic structure
+--------------------
+
+Start with the native RHF workflow, then add correlation or response only
+after the reference calculation is converged.
+
+* :doc:`Quantum chemistry overview </qchem>` -- molecule construction,
+  solver families, and integral choices.
+* :doc:`Hartree--Fock analysis </hf_analysis>` -- orbitals, populations, and
+  diagnostics after SCF.
+* :doc:`MP2 and COMP2 </mp2_comp2>` -- perturbative correlation workflows.
+* :doc:`CASCI and CASSCF <guide_qchem_mcscf>` -- active spaces, orbital
+  optimization, state averaging, and convergence controls.
+* :doc:`OM2/MRCI <guide_qchem_om2_mrci>` -- current semiempirical excited-state
+  interface and its validation limits.
+* :doc:`GW and BSE </gw_bse>` and :doc:`TDDFT/Ehrenfest
+  </tddft_ehrenfest>` -- advanced response and excited-state paths.
+
+Grid, quantum, and nonadiabatic dynamics
+----------------------------------------
+
+* :doc:`Discrete variable representations </dvr>` -- grid construction,
+  kinetic energy, Hamiltonian assembly, and diagonalization.
+* :doc:`Geometric quantum dynamics </geometric_quantum_dynamics>` --
+  geometric and locally diabatic representations.
+* :doc:`Nonadiabatic dynamics API </pyqed.namd>` -- available NAMD objects and
+  implementation entry points.
+* :doc:`TDDFT and Ehrenfest dynamics </tddft_ehrenfest>` -- coupled
+  electronic--nuclear workflows and current backend restrictions.
+
+Open systems and spectroscopy
+-----------------------------
+
+* :doc:`Open quantum dynamics <guide_open_dynamics>` -- Lindblad, Redfield,
+  time-convolutionless, and hierarchy-based concepts.
+* :doc:`HEOM and structured baths </heom>` -- solver imports, optional
+  dependencies, hierarchy controls, and reproducibility requirements.
+* :doc:`Nonlinear molecular spectroscopy <guide_spectroscopy>` --
+  sum-over-states, correlation-function, and nonperturbative viewpoints.
+
+Light--matter and periodically driven systems
+---------------------------------------------
+
+* :doc:`Floquet methods </pyqed.floquet>` -- periodically driven model
+  workflows.
+* :doc:`Polariton methods </pyqed.polariton>` -- coupled light--matter model
+  entry points.
+* :doc:`Model Hamiltonians </pyqed.models>` -- reusable model-building
+  components.
+
+Tensor networks and many-body methods
+-------------------------------------
+
+* :doc:`Matrix product states </mps>` -- MPS/MPO concepts, DMRG, package map,
+  and example entry points.
+* :doc:`Non-Abelian DMRG design </nonabelian_dmrg_design>` -- reduced-sector
+  conventions and the status of spin-adapted research paths.
+
+Reliability, reproduction, and help
+-----------------------------------
+
+* :doc:`Capability maturity </capabilities>` states which workflows are Beta
+  or Experimental and points to their evidence.
+* :doc:`Benchmarks and validation </benchmarks>` separates regression tests,
+  independent validation, and performance claims.
+* :doc:`Citing PyQED </citing>` explains software, method, version, and input
+  citation.
+* :doc:`Support and problem reports </support>` lists the information needed
+  for a useful scientific bug report.
 
 .. toctree::
-	:maxdepth: 2 
+   :hidden:
+   :maxdepth: 2
+   :caption: Foundations
 
-	guide_spectroscopy.rst
-	guide_open_dynamics.rst
-	guide_qchem_mcscf.rst
-	guide_qchem_om2_mrci.rst
+   core_workflow
+
+   ../theory
+   ../backends
+
+.. toctree::
+   :hidden:
+   :maxdepth: 2
+   :caption: Electronic structure
+
+   ../qchem
+   ../hf_analysis
+   ../mp2_comp2
+   ../gw_bse
+   ../tddft_ehrenfest
+   ../qchem_architecture
+
+.. toctree::
+   :hidden:
+   :maxdepth: 2
+   :caption: Quantum dynamics
+
+   ../dvr
+   ../geometric_quantum_dynamics
+   ../pyqed.namd
+
+.. toctree::
+   :hidden:
+   :maxdepth: 2
+   :caption: Open systems and spectra
+
+   guide_spectroscopy
+   guide_open_dynamics
+   ../heom
+
+.. toctree::
+   :hidden:
+   :maxdepth: 2
+   :caption: Light–matter systems
+
+   ../pyqed.floquet
+   ../pyqed.polariton
+   ../pyqed.models
+
+.. toctree::
+   :hidden:
+   :maxdepth: 2
+   :caption: Tensor networks
+
+   ../mps
+   ../nonabelian_dmrg_design

--- a/docs/source/guide/guide_open_dynamics.rst
+++ b/docs/source/guide/guide_open_dynamics.rst
@@ -1,50 +1,126 @@
 Open quantum dynamics
 =====================
 
-Dynamics of open quantum systems requries to solve the quantum master equaiton 
+Open-system methods describe a subsystem whose environment is not propagated
+explicitly.  The central object is the reduced density matrix
+:math:`\rho(t)`.  Its equation of motion is written in Liouville space as
 
-.. math:: 
-	
-	i \dot{\rho} = (\mathcal{L}_0 + \mathcal{L}_1) \rho 
+.. math::
 
+   \frac{d\rho}{dt} = \mathcal{L}(t)\rho,
 
-Lindblad quantum master equaiton
---------------------------------
+where the Liouvillian contains the system Hamiltonian and the selected model
+of environmental relaxation and memory.
 
-Redfield equaiton
+Choosing a method
 -----------------
 
-Time-convolutionless master equation
-------------------------------------
+.. list-table:: Open-system starting points
+   :header-rows: 1
+   :widths: 19 34 47
 
+   * - Method
+     - Appropriate starting regime
+     - Main checks
+   * - Lindblad
+     - Markovian dynamics with known jump operators and non-negative rates
+     - Trace preservation, positivity, rate and unit conventions
+   * - Redfield
+     - Weak system--bath coupling with a specified bath spectrum
+     - Born--Markov/secular assumptions and possible positivity loss
+   * - Time-convolutionless
+     - A time-local perturbative generator for weak coupling
+     - Perturbative order, validity time, and generator convergence
+   * - HEOM
+     - Structured baths or non-Markovian memory represented by exponential
+       correlation terms
+     - Time step, hierarchy depth, bath decomposition, trace, and positivity
 
-HEOM
-----
+This table is a starting point, not an automatic selector.  Derive the
+approximations from the physical time and energy scales of the problem, then
+validate a small case independently.
 
-Models 
-------
+Lindblad master equation
+------------------------
 
-* Spin-boson model
-
+For a Hamiltonian :math:`H` and jump operators :math:`L_k`, a standard
+Markovian generator is
 
 .. math::
-	H = \frac{\Delta}{2} \sigma_x  + \sum_k \sigma_z {g_k a_k^\dagger + g_k^*a_k} + \sum_k \omega_k a^\dagger_k a_k 
 
-The environmental influence to the system dynamics is encoded in the so-called spectral density, 
+   \frac{d\rho}{dt}
+   = -i[H,\rho]
+   + \sum_k \gamma_k
+     \left(L_k\rho L_k^\dagger
+     - \frac{1}{2}\{L_k^\dagger L_k,\rho\}\right).
+
+The rates :math:`\gamma_k` and operators :math:`L_k` define the physical
+model; they should not be chosen merely to reproduce a desired decay curve.
+Check that the propagated state remains Hermitian, has unit trace, and is
+positive within numerical precision.
+
+Redfield and time-convolutionless equations
+-------------------------------------------
+
+Redfield theory derives a weak-coupling generator from system operators and
+bath correlation functions.  A secular approximation may improve positivity
+but can remove physically relevant coherences when transition frequencies are
+near-degenerate.  Time-convolutionless approaches instead construct a
+time-local perturbative generator.  In both cases, record the spectral
+density, temperature convention, perturbative order, and every Markov or
+secular approximation.
+
+HEOM and bath memory
+--------------------
+
+Hierarchical equations of motion retain environmental memory through
+auxiliary density operators.  PyQED's compact current entry point implements
+a single-exponential Drude--Lorentz bath for small model studies.  The
+:doc:`HEOM guide </heom>` contains a runnable spin--boson example, expected
+output, parameter definitions, and explicit limitations.
+
+A common model is
 
 .. math::
-	J(\omega) = \sum_k |{g_k}|^2 \delta(\omega - \omega_k). 
 
-We here implement the Lorentz-Drude form 
+   H = \frac{\Delta}{2}\sigma_x + \frac{\epsilon}{2}\sigma_z
+     + \sigma_z\sum_k \left(g_k a_k^\dagger + g_k^*a_k\right)
+     + \sum_k \omega_k a_k^\dagger a_k,
 
-.. math::
-
-	J(\omega) = \frac{2\lambda \omega \gamma}{\omega^2 + \gamma^2}
-
-with a single exponential for the time-correlation function. 
+with bath spectral density
 
 .. math::
 
-	D(t) = \pi^{-1} \int_0^\infty d \omega J(\omega)(\coth(\beta\omega/2) - i \sin(\omega t)) \approx \lambda (2T - i \gamma) e^{-\gamma t}
+   J(\omega) = \sum_k |g_k|^2\delta(\omega-\omega_k).
 
+The compact HEOM solver uses the Drude--Lorentz form
 
+.. math::
+
+   J(\omega) = \frac{2\lambda\gamma\omega}
+                    {\omega^2+\gamma^2}.
+
+Here :math:`\lambda` is the reorganization energy and :math:`\gamma^{-1}` is
+the bath-memory timescale.  See :doc:`heom </heom>` for the correlation
+approximation and solver conventions actually implemented.
+
+Reliable workflow
+-----------------
+
+#. Write the system Hamiltonian, initial state, coupling operators, bath
+   spectrum, and unit convention explicitly.
+#. Check that :math:`\rho(0)` is Hermitian, positive, and normalized.
+#. Run the smallest model and monitor trace, Hermiticity, positivity, and any
+   conserved quantities.
+#. Tighten the time step and each method-specific truncation independently.
+#. Compare with an analytic limit or an independent solver where possible.
+#. Preserve the version, input, dependencies, and raw trajectory.
+
+Related material
+----------------
+
+* :doc:`/heom` -- runnable HEOM calculation and convergence controls
+* :doc:`/theory` -- density-matrix and open-system conventions
+* :doc:`/tutorials` -- recommended learning paths
+* :doc:`/examples` -- compact and research example inventory
+* :doc:`/capabilities` -- current maturity and evidence boundaries

--- a/docs/source/heom.rst
+++ b/docs/source/heom.rst
@@ -1,30 +1,162 @@
-HEOM and structured baths
-=========================
+Hierarchical equations of motion
+================================
 
-The base installation provides the conventional HEOM solver:
+The hierarchical equations of motion (HEOM) propagate a reduced density
+matrix together with auxiliary density operators (ADOs) that retain bath
+memory.  Compared with a time-local Lindblad model, HEOM is useful when a
+structured environment or non-Markovian response matters.
 
-.. code-block:: python
+When to use HEOM
+----------------
 
-   from pyqed.HEOM.heom import HEOMSolver
+Use the current PyQED HEOM solver for compact model studies with:
 
-The dissipaton-equation-of-motion (DEOM) and structured-bath helpers use
-Numba, SymPy, and tqdm. Install their declared extra before importing them:
+* a finite-dimensional system Hamiltonian;
+* one system--bath coupling operator;
+* a Drude--Lorentz bath represented by one exponential correlation term; and
+* dynamics that can be converged with a modest hierarchy depth.
+
+For a weak, rapidly relaxing bath, a Lindblad or Redfield calculation may be
+less expensive.  Baths that require several exponential terms, low-temperature
+corrections, or production-scale hierarchy filtering are beyond the current
+compact solver and should not be approximated without validation.
+
+Minimal example: spin--boson dynamics
+-------------------------------------
+
+The following calculation starts in the second diabatic state, couples
+:math:`\sigma_z` to a Drude--Lorentz bath, and records
+:math:`\langle\sigma_z\rangle` for 100 time steps.
+
+.. literalinclude:: ../../examples/heom_compact.py
+   :language: python
+   :linenos:
+
+Expected result
+~~~~~~~~~~~~~~~
+
+.. code-block:: text
+
+   Final <sigma_z>: -0.96907844
+
+``expect`` is the observable history returned by ``run``, not a density-matrix
+trajectory.  Its shape is ``(len(e_ops), nt)``; ``expect[0]`` is therefore the
+sampled :math:`\langle\sigma_z\rangle` trace.
+
+Important parameters
+--------------------
+
+``H``
+   System Hamiltonian as a square array.
+
+``rho0``
+   Initial reduced density matrix.  Check that it is Hermitian, positive, and
+   has unit trace before propagation.
+
+``c_ops``
+   System--bath coupling operators.  The current HEOM path uses the first
+   operator, ``c_ops[0]``.
+
+``e_ops``
+   Operators whose expectation values are returned at every step.  Supply at
+   least one observable.
+
+``dt``, ``nt``
+   Integration step and number of steps.  The reported time interval is
+   ``nt * dt`` in the same inverse-energy/time convention used by ``H``.
+
+``temperature``
+   Bath thermal energy :math:`k_B T` in the solver's unit convention.  The
+   current ``run`` path uses the value directly; it does not convert kelvin.
+
+``cutoff``
+   Drude cutoff :math:`\gamma`, the inverse bath-memory time.  Larger values
+   describe a faster, more nearly Markovian bath.
+
+``reorganization``
+   Reorganization energy :math:`\lambda`, which controls the bath-coupling
+   strength.
+
+``nado``
+   Number of hierarchy slots allocated, including the physical density matrix
+   and the zero terminator.  Increase it until the observable is insensitive
+   to further increases in ``nado``.
+
+Bath model and hierarchy
+------------------------
+
+The implemented Drude--Lorentz spectral density is
+
+.. math::
+
+   J(\omega) = \frac{2\lambda\gamma\omega}
+                     {\omega^2+\gamma^2}.
+
+PyQED represents its bath correlation with one decaying term,
+
+.. math::
+
+   C(t) \simeq D_0 e^{-\gamma t}, \qquad
+   D_0 = \lambda\gamma
+   \left[\coth\!\left(\frac{\gamma}{2T}\right)-i\right],
+
+where :math:`T` denotes the supplied thermal energy.  The physical reduced
+density matrix is the zeroth ADO.  Higher ADOs encode successive orders of
+bath memory and are coupled to their neighboring tiers.  PyQED closes the
+finite hierarchy by setting the next, unrepresented ADO to zero and advances
+the equations on the uniform ``dt`` grid.
+
+Convergence and limitations
+---------------------------
+
+A single trajectory is not a convergence test.  For a reported calculation:
+
+1. Repeat it with a smaller ``dt``.
+2. Increase ``nado`` until all observables of interest are stable.
+3. Extend ``nt`` to cover the full relaxation or correlation time.
+4. Monitor Hermiticity, trace, and positivity of the reduced state in a
+   validation calculation.
+5. Record the PyQED version, unit convention, bath parameters, hierarchy
+   depth, and integration settings.
+
+All Hamiltonian, bath, temperature, and time parameters must be expressed in
+one consistent unit system.  In particular, passing ``temperature=600`` does
+not by itself mean 600 K; the short example uses the solver's native numerical
+parameter convention to reproduce the stated regression value.
+
+The current implementation uses one coupling operator and one exponential
+bath term, a simple zero terminator, fixed-step propagation, and stores only
+expectation values from ``run``.  The ratio :math:`\gamma/T` is printed as a
+diagnostic; the solver warns when its thermal approximation may be unreliable.
+Strong coupling, slow baths, low temperature, or long propagation commonly
+require a deeper hierarchy and a more complete bath decomposition.
+
+DEOM and structured-bath workflows
+----------------------------------
+
+The dissipaton-equation-of-motion (DEOM) and structured-bath research modules
+use additional dependencies.  Install the declared extra before importing
+them:
 
 .. code-block:: bash
 
    python -m pip install "pyqed[heom]"
 
-Then import the DEOM solver from the same documented package namespace:
+These workflows are separate from the compact ``pyqed.oqs.HEOMSolver`` entry
+point above.  Inspect their examples and preserve every decomposition and
+truncation parameter when publishing results.
 
-.. code-block:: python
+API, source, and related material
+---------------------------------
 
-   from pyqed.HEOM.deom import DEOMSolver
-
-These modules are research workflows. Preserve the PyQED version, bath
-decomposition, hierarchy cutoff, integration settings, and convergence checks
-with any reported result.
-
-.. automodule:: pyqed.HEOM
-   :members:
-   :undoc-members:
-   :show-inheritance:
+* Solver entry point: ``pyqed.oqs.HEOMSolver`` (an alias of
+  ``pyqed.oqs.HEOM``).
+* `HEOM solver source (PyQED 0.2.0)
+  <https://github.com/binggu56/pyqed/blob/v0.2.0/pyqed/oqs.py>`__
+* `Runnable compact HEOM example
+  <https://github.com/binggu56/pyqed/blob/main/examples/heom_compact.py>`__
+* `Longer historical HEOM example (PyQED 0.2.0)
+  <https://github.com/binggu56/pyqed/blob/v0.2.0/examples/heom.py>`__
+* :doc:`guide/guide_open_dynamics` for open-system models and bath notation
+* :doc:`tutorials` for the recommended learning path
+* :doc:`examples` for Lindblad, Redfield, DEOM, and spectroscopy examples

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,21 +21,22 @@ Start here
 
 * :doc:`installation` -- create an isolated environment and verify it.
 * :doc:`quickstart` -- run a native H2 restricted Hartree--Fock calculation.
+* :doc:`guide/guide` -- choose a scientific task from the complete user guide.
 * :doc:`tutorials` -- follow a task-oriented learning path.
 * :doc:`examples` -- find an executable repository example.
 * :doc:`capabilities` -- understand Beta and Experimental status.
 * :doc:`benchmarks` -- reproduce validation and performance evidence.
 * :doc:`citing` -- cite the exact code and method used.
 
-Method areas
-------------
+User guide
+----------
 
-The development tree contains workflows for quantum chemistry, discrete and
-finite-element variable representations, nonadiabatic and geometric dynamics,
-open-system dynamics, spectroscopy, Floquet models, light--matter coupling,
-and tensor-network methods.  The presence of a module does not by itself mean
-that every configuration is supported; the capability table links each area
-to its current documentation, examples, and tests.
+The :doc:`PyQED user guide <guide/guide>` is the main map of the documentation.
+It groups existing material into foundations, electronic structure, quantum
+dynamics, open systems, light--matter models, and tensor networks.  Start with
+:doc:`how PyQED calculations work <guide/core_workflow>` if you are moving
+between method families: it explains the shared model--build--solve--validate
+workflow without making you learn every module first.
 
 .. toctree::
    :maxdepth: 2
@@ -43,42 +44,15 @@ to its current documentation, examples, and tests.
 
    installation
    quickstart
+   guide/guide
    tutorials
    examples
 
 .. toctree::
    :maxdepth: 2
-   :caption: Concepts and user guides
-
-   theory
-   guide/guide
-   backends
-   qchem
-   hf_analysis
-   mp2_comp2
-   gw_bse
-   tddft_ehrenfest
-   mps
-   dvr
-   geometric_quantum_dynamics
-   pyqed.floquet
-   pyqed.models
-   pyqed.namd
-   pyqed.polariton
-   heom
-
-.. toctree::
-   :maxdepth: 2
-   :caption: API and implementation
+   :caption: Reference and evidence
 
    api
-   qchem_architecture
-   nonabelian_dmrg_design
-
-.. toctree::
-   :maxdepth: 2
-   :caption: Evidence and citation
-
    capabilities
    benchmarks
    citing

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -5,6 +5,10 @@ PyQED is broad, so the safest route is to start with one small, inspectable
 workflow and follow its linked guide, example, and test.  The paths below do
 not imply that every combination of options is supported.
 
+Before choosing a method, read :doc:`guide/core_workflow` for the shared
+model--build--solve--inspect--validate lifecycle.  Each path below begins with
+a small calculation and then points toward the more specialized material.
+
 Quantum chemistry
 -----------------
 
@@ -22,12 +26,19 @@ GW and response calculations are separate advanced paths; begin with
 Grid and wavepacket dynamics
 ----------------------------
 
-1. Read the representation overview in :doc:`dvr`.
-2. Run ``examples/dvr/fedvr_harmonic_oscillator.py``.  It prints computed
-   eigenvalues beside the analytic harmonic-oscillator sequence.
-3. Compare grid families with ``examples/dvr/fedvr_vs_sine_quartic.py``.
-4. Move to ``examples/dvr/gwp_sddvr_2d_independent_ho.py`` only after the
-   one-dimensional smoke case is understood.
+1. Read :doc:`dvr`, including its boundary-condition and convergence advice.
+2. Run the maintained Sine-DVR smoke case:
+
+   .. code-block:: bash
+
+      PYTHONPATH=. python examples/dvr/sine_harmonic_oscillator.py
+
+   Its first four energies should be ``[0.5 1.5 2.5 3.5]``.
+3. Vary both the box and grid size until the states of interest are stable.
+4. Compare representations with ``examples/dvr/fedvr_vs_sine_quartic.py``
+   only after the one-dimensional Sine-DVR calculation is understood.
+5. Treat multidimensional and Shin--Metiu scripts as research workflows: read
+   the code and verify their model assumptions before execution.
 
 Nonadiabatic and geometric dynamics
 -----------------------------------
@@ -42,11 +53,19 @@ Nonadiabatic and geometric dynamics
 Open systems and spectroscopy
 -----------------------------
 
-1. Read :doc:`guide/guide_open_dynamics` and :doc:`heom` for open-system
-   conventions.
-2. Use ``examples/heom.py`` as an entry point, then inspect focused tests for
-   the exact solver path being used.
-3. For spectroscopy, read :doc:`guide/guide_spectroscopy` and inspect
+1. Read :doc:`guide/guide_open_dynamics` to choose between time-local master
+   equations and hierarchy-based dynamics.
+2. Run the compact, documented :doc:`HEOM <heom>` calculation:
+
+   .. code-block:: bash
+
+      PYTHONPATH=. python examples/heom_compact.py
+
+   It should finish with ``Final <sigma_z>: -0.96907844``.  Then vary the time
+   step and hierarchy depth before changing the physical model.
+3. Use ``examples/heom.py`` only when you need the longer exploratory script;
+   it contains historical comparison material and plotting imports.
+4. For spectroscopy, read :doc:`guide/guide_spectroscopy` and inspect
    ``examples/signals/absorption.py`` before the larger ``examples/2DES.py``
    workflow.
 

--- a/examples/dvr/sine_harmonic_oscillator.py
+++ b/examples/dvr/sine_harmonic_oscillator.py
@@ -1,0 +1,12 @@
+"""Solve the one-dimensional harmonic oscillator with a sine DVR."""
+
+import numpy as np
+
+from pyqed.dvr import SineDVR
+
+
+dvr = SineDVR(-8.0, 8.0, 80)
+hamiltonian = dvr.t() + np.diag(0.5 * dvr.x**2)
+energies = np.linalg.eigvalsh(hamiltonian)[:4]
+
+print(np.array2string(energies, precision=8))

--- a/examples/heom_compact.py
+++ b/examples/heom_compact.py
@@ -1,0 +1,18 @@
+"""Propagate a two-level system with the compact HEOM solver."""
+
+import numpy as np
+
+from pyqed import pauli
+from pyqed.oqs import HEOMSolver
+
+
+_, sx, _, sz = pauli()
+hamiltonian = -0.5 * (sx + sz)
+rho0 = np.diag([0.0, 1.0])
+
+expect = HEOMSolver(hamiltonian, c_ops=[sz], e_ops=[sz]).run(
+    rho0, dt=0.02, nt=100, temperature=600,
+    cutoff=5, reorganization=0.2, nado=5,
+)
+
+print(f"Final <sigma_z>: {expect[0, -1].real:.8f}")


### PR DESCRIPTION
## Summary

- reorganize the documentation around a grouped, task-oriented User Guide
- add a shared model → build → solve → inspect → validate workflow page
- turn the Sine DVR and HEOM pages into complete method guides with verified runnable examples
- curate the examples gallery and add compact tracked Sine-DVR and HEOM scripts
- adopt the PyData Sphinx theme with nested navigation, search, page TOCs, previous/next links, Show Source, and copy buttons
- refresh open-system guidance, documentation build instructions, and capability evidence links

## Why

PyQED already had substantial technical documentation, but most of it was exposed as a flat collection of pages. This made it difficult for a new reader to choose a method, find the smallest runnable example, or understand the checks required before using a research workflow. The new guide follows the layered organization used by projects such as PySCF while reusing PyQED's existing canonical pages instead of duplicating them.

## User impact

Readers now get a clear route from installation to a scientific method, executable code is shown directly in the web guide, and every featured method page includes expected output, important parameters, convergence guidance, limitations, and source links. Existing document URLs remain intact.

## Validation

- `python -m sphinx -E -W --keep-going -b html docs/source /private/tmp/pyqed-user-guide-html-final`
- Sine DVR example: `[0.5 1.5 2.5 3.5]`
- HEOM example: `Final <sigma_z>: -0.96907844`
- desktop and 390 px mobile browser checks: no horizontal overflow
- copy buttons, grouped side navigation, page TOC, Show Source, canonical metadata, and analytics asset verified in generated HTML
- browser console check completed without warnings or errors

## Stack

This PR targets `codex/docs-analytics-source` and therefore includes the source-browser/analytics work from #58. After #58 merges, this PR can be retargeted to `main`.