### PR TITLE
Add interactive molecular viewer

### DIFF
--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -59,6 +59,12 @@ button {
   font: inherit;
 }
 
+textarea,
+select,
+input {
+  font: inherit;
+}
+
 a:focus-visible,
 button:focus-visible,
 summary:focus-visible {
@@ -223,6 +229,373 @@ summary:focus-visible {
 .mobile-menu nav a:last-child {
   border-bottom: 0;
   color: var(--cyan);
+}
+
+/* Interactive molecular viewer */
+
+.viewer-page {
+  min-height: calc(100vh - 86px);
+  padding: 64px 0 96px;
+  background:
+    radial-gradient(circle at 76% 18%, rgba(53, 214, 227, 0.1), transparent 28%),
+    linear-gradient(145deg, #07151f 0%, #0a1b27 52%, #07141e 100%);
+}
+
+.viewer-nav > p {
+  margin: 0;
+  color: #9db1b8;
+  font-size: 0.72rem;
+  font-weight: 760;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.viewer-intro {
+  display: grid;
+  grid-template-columns: minmax(0, 1.3fr) minmax(300px, 0.7fr);
+  align-items: end;
+  gap: 5rem;
+  margin-bottom: 42px;
+}
+
+.viewer-intro .kicker {
+  margin-bottom: 0.7rem;
+}
+
+.viewer-intro h1 {
+  max-width: 810px;
+  margin-bottom: 0;
+  font-size: clamp(3rem, 5vw, 5.25rem);
+}
+
+.viewer-intro > p {
+  margin: 0 0 0.5rem;
+  color: #a7bac0;
+  line-height: 1.75;
+}
+
+.viewer-workspace {
+  display: grid;
+  min-height: 680px;
+  grid-template-columns: minmax(300px, 0.34fr) minmax(0, 0.66fr);
+  border: 1px solid var(--rule-dark);
+  box-shadow: 0 34px 80px rgba(0, 0, 0, 0.24);
+}
+
+.viewer-input-panel {
+  padding: 28px;
+  border-right: 1px solid var(--rule-dark);
+  background: #0c1e2a;
+}
+
+.panel-heading {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  margin-bottom: 1.6rem;
+}
+
+.panel-heading > span {
+  color: var(--cyan);
+  font-family: var(--mono);
+  font-size: 0.72rem;
+}
+
+.panel-heading p {
+  margin-bottom: 0.2rem;
+  color: #8299a1;
+  font-size: 0.69rem;
+  font-weight: 760;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.panel-heading h2 {
+  margin: 0;
+  font-family: var(--serif);
+  font-size: 1.8rem;
+  font-weight: 400;
+}
+
+.preset-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-bottom: 1.5rem;
+}
+
+.preset-row button,
+.viewer-controls button {
+  min-height: 36px;
+  border: 1px solid rgba(168, 238, 242, 0.23);
+  background: rgba(255, 255, 255, 0.025);
+  color: #b8c9ce;
+  cursor: pointer;
+  font-size: 0.68rem;
+  font-weight: 720;
+  letter-spacing: 0.045em;
+}
+
+.preset-row button {
+  padding: 0.4rem 0.65rem;
+}
+
+.preset-row button:hover,
+.viewer-controls button:hover,
+.viewer-controls button.is-active {
+  border-color: var(--cyan);
+  color: var(--cyan-soft);
+}
+
+.viewer-controls button.is-active {
+  background: rgba(53, 214, 227, 0.1);
+}
+
+.field-label,
+.unit-control,
+.viewer-controls label {
+  color: #aec0c5;
+  font-size: 0.69rem;
+  font-weight: 760;
+  letter-spacing: 0.065em;
+  text-transform: uppercase;
+}
+
+.viewer-input-panel textarea {
+  width: 100%;
+  min-height: 300px;
+  margin-top: 0.55rem;
+  padding: 1rem;
+  resize: vertical;
+  border: 1px solid rgba(168, 238, 242, 0.2);
+  border-radius: 0;
+  outline: none;
+  background: #071720;
+  color: #d8e6e8;
+  font-family: var(--mono);
+  font-size: 0.76rem;
+  line-height: 1.65;
+}
+
+.viewer-input-panel textarea:focus,
+.viewer-input-panel select:focus,
+.viewer-controls select:focus {
+  border-color: var(--cyan);
+  box-shadow: 0 0 0 2px rgba(53, 214, 227, 0.1);
+}
+
+.field-help {
+  margin: 0.6rem 0 1.1rem;
+  color: #7f969e;
+  font-size: 0.7rem;
+  line-height: 1.55;
+}
+
+.field-help code {
+  color: #b9dadd;
+  font-family: var(--mono);
+}
+
+.viewer-error {
+  margin: -0.35rem 0 1rem;
+  padding: 0.65rem 0.75rem;
+  border-left: 2px solid #ff827c;
+  background: rgba(239, 83, 80, 0.09);
+  color: #ffb0ac;
+  font-size: 0.74rem;
+}
+
+.input-actions {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
+}
+
+.file-button,
+.unit-control {
+  display: flex;
+  min-height: 44px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(168, 238, 242, 0.28);
+  color: #b9cbd0;
+}
+
+.file-button {
+  cursor: pointer;
+}
+
+.file-button:hover {
+  border-color: var(--cyan);
+  color: var(--cyan-soft);
+}
+
+.file-button input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+}
+
+.unit-control {
+  gap: 0.45rem;
+  padding: 0 0.45rem 0 0.7rem;
+  justify-content: space-between;
+}
+
+.unit-control select,
+.viewer-controls select {
+  border: 1px solid rgba(168, 238, 242, 0.24);
+  border-radius: 0;
+  outline: none;
+  background: #071720;
+  color: #d8e6e8;
+}
+
+.unit-control select {
+  max-width: 94px;
+  padding: 0.4rem;
+  font-size: 0.72rem;
+}
+
+.viewer-update {
+  width: 100%;
+  grid-column: 1 / -1;
+  border: 0;
+  cursor: pointer;
+}
+
+.viewer-display-panel {
+  display: grid;
+  min-width: 0;
+  grid-template-rows: auto minmax(480px, 1fr) auto;
+  background: #071720;
+}
+
+.viewer-toolbar {
+  display: flex;
+  min-height: 90px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--rule-dark);
+  background: #0a1b26;
+}
+
+.molecule-identity {
+  display: grid;
+  flex: 0 0 auto;
+}
+
+.molecule-identity > span {
+  color: var(--cyan);
+  font-size: 0.62rem;
+  font-weight: 760;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.molecule-identity strong {
+  margin: 0.12rem 0;
+  font-family: var(--serif);
+  font-size: 1.55rem;
+  font-weight: 400;
+  line-height: 1.1;
+}
+
+.molecule-identity small {
+  color: #8298a0;
+  font-size: 0.66rem;
+}
+
+.viewer-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: end;
+  justify-content: flex-end;
+  gap: 0.45rem;
+}
+
+.viewer-controls label {
+  display: grid;
+  gap: 0.28rem;
+}
+
+.viewer-controls select {
+  min-height: 36px;
+  padding: 0 0.55rem;
+  font-size: 0.7rem;
+  text-transform: none;
+}
+
+.viewer-controls button {
+  padding: 0.4rem 0.6rem;
+}
+
+.molecule-canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  min-height: 480px;
+  cursor: grab;
+  touch-action: none;
+}
+
+.molecule-canvas:active {
+  cursor: grabbing;
+}
+
+.viewer-footer-bar {
+  display: flex;
+  min-height: 62px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 1.25rem;
+  border-top: 1px solid var(--rule-dark);
+  background: #0a1b26;
+}
+
+.element-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem 1rem;
+}
+
+.element-legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: #96aab1;
+  font-size: 0.67rem;
+}
+
+.element-legend i {
+  width: 9px;
+  height: 9px;
+  border: 1px solid rgba(255, 255, 255, 0.42);
+  border-radius: 50%;
+}
+
+.export-button {
+  flex: 0 0 auto;
+  min-height: 38px;
+  padding: 0.45rem 0.8rem;
+  border: 1px solid var(--cyan);
+  background: transparent;
+  color: var(--cyan-soft);
+  cursor: pointer;
+  font-size: 0.68rem;
+  font-weight: 760;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.export-button:hover {
+  background: var(--cyan);
+  color: var(--navy);
 }
 
 .hero {
@@ -1710,6 +2083,27 @@ footer {
     display: block;
   }
 
+  .viewer-nav {
+    grid-template-columns: 1fr auto 1fr;
+  }
+
+  .viewer-intro {
+    gap: 2.5rem;
+  }
+
+  .viewer-workspace {
+    grid-template-columns: minmax(275px, 0.4fr) minmax(0, 0.6fr);
+  }
+
+  .viewer-toolbar {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .viewer-controls {
+    justify-content: flex-start;
+  }
+
   .hero-content {
     min-height: 650px;
     grid-template-columns: minmax(0, 1fr) minmax(300px, 0.6fr);
@@ -1754,6 +2148,65 @@ footer {
 
   .nav-actions > a {
     display: none;
+  }
+
+  .viewer-nav {
+    grid-template-columns: 1fr auto;
+  }
+
+  .viewer-nav > p {
+    justify-self: end;
+  }
+
+  .viewer-nav .nav-actions {
+    display: none;
+  }
+
+  .viewer-page {
+    padding: 48px 0 64px;
+  }
+
+  .viewer-intro,
+  .viewer-workspace {
+    display: block;
+  }
+
+  .viewer-intro {
+    margin-bottom: 30px;
+  }
+
+  .viewer-intro h1 {
+    font-size: clamp(2.8rem, 13vw, 4rem);
+  }
+
+  .viewer-intro > p {
+    margin-top: 1.5rem;
+  }
+
+  .viewer-input-panel {
+    border-right: 0;
+    border-bottom: 1px solid var(--rule-dark);
+  }
+
+  .viewer-input-panel textarea {
+    min-height: 250px;
+  }
+
+  .viewer-display-panel {
+    grid-template-rows: auto 430px auto;
+  }
+
+  .molecule-canvas {
+    min-height: 430px;
+  }
+
+  .viewer-footer-bar {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .export-button {
+    width: 100%;
   }
 
   .mobile-menu nav {

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -259,6 +259,7 @@ const softwareJsonLd = {
 
 const navigation = [
   ["Workflows", "#workflows"],
+  ["Viewer", "/viewer"],
   ["Quickstart", "#quickstart"],
   ["Examples", "/examples"],
   ["Evidence", "#evidence"],

--- a/website/app/sitemap.ts
+++ b/website/app/sitemap.ts
@@ -15,6 +15,11 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.8,
     },
     {
+      url: "https://pyqed.org/viewer",
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+    {
       url: "https://pyqed.org/privacy",
       changeFrequency: "yearly",
       priority: 0.2,

--- a/website/app/viewer/molecule-viewer.tsx
+++ b/website/app/viewer/molecule-viewer.tsx
@@ -1,0 +1,592 @@
+"use client";
+
+import type {
+  ChangeEvent,
+  PointerEvent as ReactPointerEvent,
+  WheelEvent as ReactWheelEvent,
+} from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+type Atom = {
+  element: string;
+  x: number;
+  y: number;
+  z: number;
+};
+
+type Bond = [number, number];
+type RenderMode = "ball-stick" | "space-fill" | "wireframe";
+
+const BOHR_TO_ANGSTROM = 0.529177210903;
+
+const ELEMENTS: Record<
+  string,
+  { color: string; radius: number; covalent: number; name: string }
+> = {
+  H: { color: "#f4f5f6", radius: 0.31, covalent: 0.31, name: "Hydrogen" },
+  B: { color: "#f4a67c", radius: 0.84, covalent: 0.84, name: "Boron" },
+  C: { color: "#475965", radius: 0.76, covalent: 0.76, name: "Carbon" },
+  N: { color: "#5085e8", radius: 0.71, covalent: 0.71, name: "Nitrogen" },
+  O: { color: "#ef5350", radius: 0.66, covalent: 0.66, name: "Oxygen" },
+  F: { color: "#74c985", radius: 0.57, covalent: 0.57, name: "Fluorine" },
+  P: { color: "#e29a45", radius: 1.07, covalent: 1.07, name: "Phosphorus" },
+  S: { color: "#e8cb4b", radius: 1.05, covalent: 1.05, name: "Sulfur" },
+  Cl: { color: "#62bd6b", radius: 1.02, covalent: 1.02, name: "Chlorine" },
+  Fe: { color: "#bf6a43", radius: 1.32, covalent: 1.32, name: "Iron" },
+  Br: { color: "#a34f45", radius: 1.20, covalent: 1.20, name: "Bromine" },
+  I: { color: "#8b63b8", radius: 1.39, covalent: 1.39, name: "Iodine" },
+};
+
+const FALLBACK_ELEMENT = {
+  color: "#8fa6b0",
+  radius: 0.9,
+  covalent: 0.9,
+  name: "Element",
+};
+
+const PRESETS = {
+  Water: `3
+Water · H2O
+O  0.000000  0.000000  0.000000
+H  0.000000 -0.757000  0.587000
+H  0.000000  0.757000  0.587000`,
+  Methane: `5
+Methane · CH4
+C  0.000000  0.000000  0.000000
+H  0.629118  0.629118  0.629118
+H -0.629118 -0.629118  0.629118
+H -0.629118  0.629118 -0.629118
+H  0.629118 -0.629118 -0.629118`,
+  Benzene: `12
+Benzene · C6H6
+C  1.396000  0.000000  0.000000
+C  0.698000  1.209000  0.000000
+C -0.698000  1.209000  0.000000
+C -1.396000  0.000000  0.000000
+C -0.698000 -1.209000  0.000000
+C  0.698000 -1.209000  0.000000
+H  2.479000  0.000000  0.000000
+H  1.240000  2.147000  0.000000
+H -1.240000  2.147000  0.000000
+H -2.479000  0.000000  0.000000
+H -1.240000 -2.147000  0.000000
+H  1.240000 -2.147000  0.000000`,
+  "Hydrogen fluoride": `2
+Hydrogen fluoride · HF
+H 0.000000 0.000000 0.000000
+F 0.000000 0.000000 0.917000`,
+} as const;
+
+function canonicalElement(value: string): string {
+  const trimmed = value.trim();
+  if (!/^[A-Za-z]{1,2}$/.test(trimmed)) {
+    throw new Error(`Invalid element symbol “${value}”.`);
+  }
+  return trimmed[0].toUpperCase() + trimmed.slice(1).toLowerCase();
+}
+
+export function parseGeometry(text: string, unit: "angstrom" | "bohr"): Atom[] {
+  const normalized = text.replaceAll(";", "\n").trim();
+  if (!normalized) throw new Error("Enter at least one atom.");
+
+  const rawLines = normalized.split(/\r?\n/).map((line) => line.trim());
+  const firstIsCount = /^\d+$/.test(rawLines[0]);
+  const expectedCount = firstIsCount ? Number(rawLines[0]) : null;
+  const coordinateLines = firstIsCount ? rawLines.slice(2) : rawLines;
+  const scale = unit === "bohr" ? BOHR_TO_ANGSTROM : 1;
+
+  const atoms = coordinateLines
+    .filter(Boolean)
+    .map((line, index) => {
+      const fields = line.split(/[\s,]+/);
+      if (fields.length !== 4) {
+        throw new Error(
+          `Line ${index + (firstIsCount ? 3 : 1)} must contain an element and three coordinates.`,
+        );
+      }
+      const [symbol, ...coordinateText] = fields;
+      const coordinates = coordinateText.map(Number);
+      if (coordinates.some((value) => !Number.isFinite(value))) {
+        throw new Error(`Line ${index + (firstIsCount ? 3 : 1)} contains an invalid number.`);
+      }
+      return {
+        element: canonicalElement(symbol),
+        x: coordinates[0] * scale,
+        y: coordinates[1] * scale,
+        z: coordinates[2] * scale,
+      };
+    });
+
+  if (atoms.length === 0) throw new Error("No coordinate rows were found.");
+  if (atoms.length > 500) throw new Error("The viewer currently supports up to 500 atoms.");
+  if (expectedCount !== null && expectedCount !== atoms.length) {
+    throw new Error(`XYZ header declares ${expectedCount} atoms, but ${atoms.length} were found.`);
+  }
+  return atoms;
+}
+
+function inferBonds(atoms: Atom[]): Bond[] {
+  const bonds: Bond[] = [];
+  for (let i = 0; i < atoms.length; i += 1) {
+    for (let j = i + 1; j < atoms.length; j += 1) {
+      const a = atoms[i];
+      const b = atoms[j];
+      const distance = Math.hypot(a.x - b.x, a.y - b.y, a.z - b.z);
+      const ra = (ELEMENTS[a.element] ?? FALLBACK_ELEMENT).covalent;
+      const rb = (ELEMENTS[b.element] ?? FALLBACK_ELEMENT).covalent;
+      if (distance > 0.1 && distance <= (ra + rb) * 1.22) bonds.push([i, j]);
+    }
+  }
+  return bonds;
+}
+
+function formulaFor(atoms: Atom[]): string {
+  const counts = new Map<string, number>();
+  for (const atom of atoms) counts.set(atom.element, (counts.get(atom.element) ?? 0) + 1);
+  const symbols = [...counts.keys()].sort((a, b) => {
+    const order = (symbol: string) => (symbol === "C" ? 0 : symbol === "H" ? 1 : 2);
+    return order(a) - order(b) || a.localeCompare(b);
+  });
+  return symbols.map((symbol) => `${symbol}${counts.get(symbol) === 1 ? "" : counts.get(symbol)}`).join("");
+}
+
+function xyzFor(atoms: Atom[]): string {
+  const rows = atoms.map(
+    ({ element, x, y, z }) =>
+      `${element.padEnd(2)} ${x.toFixed(8).padStart(13)} ${y.toFixed(8).padStart(13)} ${z.toFixed(8).padStart(13)}`,
+  );
+  return `${atoms.length}\nExported from the PyQED molecular viewer · coordinates in angstrom\n${rows.join("\n")}\n`;
+}
+
+function MoleculeCanvas({
+  atoms,
+  bonds,
+  mode,
+  labels,
+  autoRotate,
+  resetSignal,
+}: {
+  atoms: Atom[];
+  bonds: Bond[];
+  mode: RenderMode;
+  labels: boolean;
+  autoRotate: boolean;
+  resetSignal: number;
+}) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const rotation = useRef({ x: -0.28, y: 0.55 });
+  const zoom = useRef(1);
+  const drag = useRef<{ x: number; y: number; pointerId: number } | null>(null);
+  const animationFrame = useRef<number | null>(null);
+  const autoRotateRef = useRef(autoRotate);
+
+  useEffect(() => {
+    autoRotateRef.current = autoRotate;
+  }, [autoRotate]);
+
+  useEffect(() => {
+    rotation.current = { x: -0.28, y: 0.55 };
+    zoom.current = 1;
+  }, [resetSignal, atoms]);
+
+  const draw = useCallback(function drawFrame() {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const rect = canvas.getBoundingClientRect();
+    const pixelRatio = Math.min(window.devicePixelRatio || 1, 2);
+    const width = Math.max(1, Math.round(rect.width * pixelRatio));
+    const height = Math.max(1, Math.round(rect.height * pixelRatio));
+    if (canvas.width !== width || canvas.height !== height) {
+      canvas.width = width;
+      canvas.height = height;
+    }
+    const context = canvas.getContext("2d");
+    if (!context) return;
+    context.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
+
+    const cssWidth = rect.width;
+    const cssHeight = rect.height;
+    const gradient = context.createRadialGradient(
+      cssWidth * 0.52,
+      cssHeight * 0.46,
+      0,
+      cssWidth * 0.5,
+      cssHeight * 0.5,
+      Math.max(cssWidth, cssHeight) * 0.72,
+    );
+    gradient.addColorStop(0, "#132d3b");
+    gradient.addColorStop(0.62, "#091923");
+    gradient.addColorStop(1, "#06131c");
+    context.fillStyle = gradient;
+    context.fillRect(0, 0, cssWidth, cssHeight);
+
+    if (autoRotateRef.current && !drag.current) rotation.current.y += 0.0035;
+
+    const center = atoms.reduce(
+      (sum, atom) => ({ x: sum.x + atom.x, y: sum.y + atom.y, z: sum.z + atom.z }),
+      { x: 0, y: 0, z: 0 },
+    );
+    center.x /= atoms.length;
+    center.y /= atoms.length;
+    center.z /= atoms.length;
+
+    const spread = Math.max(
+      1.2,
+      ...atoms.map((atom) => Math.hypot(atom.x - center.x, atom.y - center.y, atom.z - center.z)),
+    );
+    const scale = (Math.min(cssWidth, cssHeight) * 0.34 * zoom.current) / spread;
+    const sinX = Math.sin(rotation.current.x);
+    const cosX = Math.cos(rotation.current.x);
+    const sinY = Math.sin(rotation.current.y);
+    const cosY = Math.cos(rotation.current.y);
+
+    const projected = atoms.map((atom, index) => {
+      const x0 = atom.x - center.x;
+      const y0 = atom.y - center.y;
+      const z0 = atom.z - center.z;
+      const x1 = x0 * cosY + z0 * sinY;
+      const z1 = -x0 * sinY + z0 * cosY;
+      const y1 = y0 * cosX - z1 * sinX;
+      const z2 = y0 * sinX + z1 * cosX;
+      return {
+        index,
+        x: cssWidth / 2 + x1 * scale,
+        y: cssHeight / 2 - y1 * scale,
+        z: z2,
+      };
+    });
+
+    const bondWidth = mode === "wireframe" ? 2 : Math.max(4, Math.min(10, scale * 0.055));
+    const sortedBonds = bonds
+      .map(([a, b]) => ({ a: projected[a], b: projected[b], depth: (projected[a].z + projected[b].z) / 2 }))
+      .sort((left, right) => left.depth - right.depth);
+
+    for (const bond of sortedBonds) {
+      const midpointX = (bond.a.x + bond.b.x) / 2;
+      const midpointY = (bond.a.y + bond.b.y) / 2;
+      context.lineCap = "round";
+      context.lineWidth = bondWidth;
+      context.strokeStyle = mode === "wireframe" ? "rgba(169, 225, 231, 0.72)" : "#80939c";
+      context.beginPath();
+      context.moveTo(bond.a.x, bond.a.y);
+      context.lineTo(midpointX, midpointY);
+      context.stroke();
+      context.strokeStyle = mode === "wireframe" ? "rgba(169, 225, 231, 0.72)" : "#b4c1c5";
+      context.beginPath();
+      context.moveTo(midpointX, midpointY);
+      context.lineTo(bond.b.x, bond.b.y);
+      context.stroke();
+    }
+
+    if (mode !== "wireframe") {
+      const sortedAtoms = [...projected].sort((a, b) => a.z - b.z);
+      for (const point of sortedAtoms) {
+        const atom = atoms[point.index];
+        const element = ELEMENTS[atom.element] ?? FALLBACK_ELEMENT;
+        const radiusScale = mode === "space-fill" ? 0.42 + element.radius * 0.5 : 0.34;
+        const radius = Math.max(8, Math.min(42, scale * radiusScale));
+        const sphere = context.createRadialGradient(
+          point.x - radius * 0.32,
+          point.y - radius * 0.38,
+          radius * 0.08,
+          point.x,
+          point.y,
+          radius,
+        );
+        sphere.addColorStop(0, "#ffffff");
+        sphere.addColorStop(0.18, element.color);
+        sphere.addColorStop(1, "#101a20");
+        context.fillStyle = sphere;
+        context.beginPath();
+        context.arc(point.x, point.y, radius, 0, Math.PI * 2);
+        context.fill();
+        context.strokeStyle = "rgba(255, 255, 255, 0.22)";
+        context.lineWidth = 1;
+        context.stroke();
+      }
+    }
+
+    if (labels) {
+      context.font = "700 12px ui-sans-serif, system-ui, sans-serif";
+      context.textAlign = "center";
+      context.textBaseline = "middle";
+      for (const point of projected) {
+        const label = `${atoms[point.index].element}${point.index + 1}`;
+        const metrics = context.measureText(label);
+        const labelWidth = metrics.width + 10;
+        context.fillStyle = "rgba(3, 15, 22, 0.78)";
+        context.fillRect(point.x - labelWidth / 2, point.y - 10, labelWidth, 20);
+        context.fillStyle = "#e7f7f8";
+        context.fillText(label, point.x, point.y + 0.5);
+      }
+    }
+
+    context.fillStyle = "rgba(168, 238, 242, 0.62)";
+    context.font = "600 11px ui-monospace, monospace";
+    context.textAlign = "left";
+    context.fillText("DRAG TO ROTATE  ·  SCROLL TO ZOOM", 18, cssHeight - 18);
+    animationFrame.current = window.requestAnimationFrame(drawFrame);
+  }, [atoms, bonds, labels, mode]);
+
+  useEffect(() => {
+    animationFrame.current = window.requestAnimationFrame(draw);
+    return () => {
+      if (animationFrame.current !== null) window.cancelAnimationFrame(animationFrame.current);
+    };
+  }, [draw]);
+
+  function handlePointerDown(event: ReactPointerEvent<HTMLCanvasElement>) {
+    event.currentTarget.setPointerCapture(event.pointerId);
+    drag.current = { x: event.clientX, y: event.clientY, pointerId: event.pointerId };
+  }
+
+  function handlePointerMove(event: ReactPointerEvent<HTMLCanvasElement>) {
+    if (!drag.current || drag.current.pointerId !== event.pointerId) return;
+    rotation.current.y += (event.clientX - drag.current.x) * 0.009;
+    rotation.current.x = Math.max(
+      -Math.PI / 2,
+      Math.min(Math.PI / 2, rotation.current.x + (event.clientY - drag.current.y) * 0.009),
+    );
+    drag.current = { x: event.clientX, y: event.clientY, pointerId: event.pointerId };
+  }
+
+  function handlePointerUp(event: ReactPointerEvent<HTMLCanvasElement>) {
+    if (drag.current?.pointerId === event.pointerId) drag.current = null;
+  }
+
+  function handleWheel(event: ReactWheelEvent<HTMLCanvasElement>) {
+    event.preventDefault();
+    zoom.current = Math.max(0.45, Math.min(3.5, zoom.current * Math.exp(-event.deltaY * 0.001)));
+  }
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="molecule-canvas"
+      aria-label={`Interactive three-dimensional molecular view with ${atoms.length} atoms and ${bonds.length} inferred bonds`}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={handlePointerUp}
+      onWheel={handleWheel}
+    />
+  );
+}
+
+export function MoleculeViewer() {
+  const [source, setSource] = useState<string>(PRESETS.Water);
+  const [unit, setUnit] = useState<"angstrom" | "bohr">("angstrom");
+  const [atoms, setAtoms] = useState<Atom[]>(() => parseGeometry(PRESETS.Water, "angstrom"));
+  const [error, setError] = useState<string | null>(null);
+  const [mode, setMode] = useState<RenderMode>("ball-stick");
+  const [labels, setLabels] = useState(false);
+  const [autoRotate, setAutoRotate] = useState(true);
+  const [resetSignal, setResetSignal] = useState(0);
+  const bonds = useMemo(() => inferBonds(atoms), [atoms]);
+  const formula = useMemo(() => formulaFor(atoms), [atoms]);
+
+  useEffect(() => {
+    const frame = window.requestAnimationFrame(() => {
+      const parameters = new URLSearchParams(window.location.hash.slice(1));
+      const geometry = parameters.get("xyz");
+      if (!geometry) return;
+
+      try {
+        setAtoms(parseGeometry(geometry, "angstrom"));
+        setSource(geometry);
+        setUnit("angstrom");
+        setError(null);
+        const requestedMode = parameters.get("representation");
+        if (
+          requestedMode === "ball-stick" ||
+          requestedMode === "space-fill" ||
+          requestedMode === "wireframe"
+        ) {
+          setMode(requestedMode);
+        }
+        setLabels(parameters.get("labels") === "1");
+        setResetSignal((value) => value + 1);
+      } catch (parseError) {
+        setError(
+          parseError instanceof Error
+            ? `Could not load the linked geometry: ${parseError.message}`
+            : "Could not load the linked geometry.",
+        );
+      }
+    });
+
+    return () => window.cancelAnimationFrame(frame);
+  }, []);
+
+  function updateGeometry(nextSource = source, nextUnit = unit) {
+    try {
+      setAtoms(parseGeometry(nextSource, nextUnit));
+      setError(null);
+      setResetSignal((value) => value + 1);
+    } catch (parseError) {
+      setError(parseError instanceof Error ? parseError.message : "Could not read this geometry.");
+    }
+  }
+
+  function selectPreset(name: keyof typeof PRESETS) {
+    const nextSource = PRESETS[name];
+    setSource(nextSource);
+    setUnit("angstrom");
+    updateGeometry(nextSource, "angstrom");
+  }
+
+  async function handleFile(event: ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    if (file.size > 1_000_000) {
+      setError("Choose an XYZ file smaller than 1 MB.");
+      return;
+    }
+    const nextSource = await file.text();
+    setSource(nextSource);
+    setUnit("angstrom");
+    updateGeometry(nextSource, "angstrom");
+    event.target.value = "";
+  }
+
+  function downloadXyz() {
+    const url = URL.createObjectURL(new Blob([xyzFor(atoms)], { type: "chemical/x-xyz" }));
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = `${formula.toLowerCase() || "molecule"}.xyz`;
+    anchor.click();
+    URL.revokeObjectURL(url);
+  }
+
+  return (
+    <section className="viewer-workspace shell" aria-label="Molecular geometry workspace">
+      <aside className="viewer-input-panel">
+        <div className="panel-heading">
+          <span>01</span>
+          <div>
+            <p>Geometry input</p>
+            <h2>Coordinates</h2>
+          </div>
+        </div>
+
+        <div className="preset-row" aria-label="Example molecules">
+          {(Object.keys(PRESETS) as (keyof typeof PRESETS)[]).map((name) => (
+            <button key={name} type="button" onClick={() => selectPreset(name)}>
+              {name}
+            </button>
+          ))}
+        </div>
+
+        <label className="field-label" htmlFor="geometry-source">
+          XYZ or PyQED atom string
+        </label>
+        <textarea
+          id="geometry-source"
+          value={source}
+          onChange={(event) => setSource(event.target.value)}
+          spellCheck={false}
+          aria-describedby="geometry-help geometry-error"
+        />
+        <p className="field-help" id="geometry-help">
+          One atom per line, or use semicolons: <code>H 0 0 0; H 0 0 0.74</code>
+        </p>
+        {error ? (
+          <p className="viewer-error" id="geometry-error" role="alert">
+            {error}
+          </p>
+        ) : null}
+
+        <div className="input-actions">
+          <label className="file-button">
+            Open XYZ
+            <input accept=".xyz,text/plain,chemical/x-xyz" onChange={handleFile} type="file" />
+          </label>
+          <label className="unit-control">
+            Input unit
+            <select
+              value={unit}
+              onChange={(event) => setUnit(event.target.value as "angstrom" | "bohr")}
+            >
+              <option value="angstrom">Ångström</option>
+              <option value="bohr">Bohr</option>
+            </select>
+          </label>
+          <button className="button button-primary viewer-update" type="button" onClick={() => updateGeometry()}>
+            Update view
+          </button>
+        </div>
+      </aside>
+
+      <div className="viewer-display-panel">
+        <div className="viewer-toolbar">
+          <div className="molecule-identity">
+            <span>Live structure</span>
+            <strong>{formula}</strong>
+            <small>{atoms.length} atoms · {bonds.length} inferred bonds</small>
+          </div>
+          <div className="viewer-controls" aria-label="Viewer controls">
+            <label>
+              Representation
+              <select value={mode} onChange={(event) => setMode(event.target.value as RenderMode)}>
+                <option value="ball-stick">Ball &amp; stick</option>
+                <option value="space-fill">Space filling</option>
+                <option value="wireframe">Wireframe</option>
+              </select>
+            </label>
+            <button
+              type="button"
+              className={labels ? "is-active" : ""}
+              aria-pressed={labels}
+              onClick={() => setLabels((value) => !value)}
+            >
+              Labels
+            </button>
+            <button
+              type="button"
+              className={autoRotate ? "is-active" : ""}
+              aria-pressed={autoRotate}
+              onClick={() => setAutoRotate((value) => !value)}
+            >
+              Auto-rotate
+            </button>
+            <button type="button" onClick={() => setResetSignal((value) => value + 1)}>
+              Reset view
+            </button>
+          </div>
+        </div>
+
+        <MoleculeCanvas
+          atoms={atoms}
+          bonds={bonds}
+          mode={mode}
+          labels={labels}
+          autoRotate={autoRotate}
+          resetSignal={resetSignal}
+        />
+
+        <div className="viewer-footer-bar">
+          <div className="element-legend" aria-label="Elements in molecule">
+            {[...new Set(atoms.map((atom) => atom.element))].map((symbol) => {
+              const element = ELEMENTS[symbol] ?? FALLBACK_ELEMENT;
+              return (
+                <span key={symbol}>
+                  <i style={{ background: element.color }} />
+                  {symbol} · {element.name}
+                </span>
+              );
+            })}
+          </div>
+          <button type="button" className="export-button" onClick={downloadXyz}>
+            Export XYZ <span aria-hidden="true">↓</span>
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/website/app/viewer/page.tsx
+++ b/website/app/viewer/page.tsx
@@ -1,0 +1,58 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { MoleculeViewer } from "./molecule-viewer";
+
+export const metadata: Metadata = {
+  title: "Interactive Molecular Viewer",
+  description:
+    "Explore molecular geometries in the browser and export coordinates for PyQED calculations.",
+  alternates: { canonical: "/viewer" },
+  openGraph: {
+    url: "https://pyqed.org/viewer",
+    title: "Interactive Molecular Viewer | PyQED",
+    description:
+      "Rotate, inspect, and export molecular geometries for PyQED calculations.",
+  },
+};
+
+export default function ViewerPage() {
+  return (
+    <>
+      <a className="skip-link" href="#viewer-main">
+        Skip to viewer
+      </a>
+
+      <header className="site-header">
+        <nav className="site-nav shell viewer-nav" aria-label="Primary navigation">
+          <Link className="wordmark" href="/" aria-label="PyQED home">
+            <span className="wordmark-mark">P</span>
+            <span>PyQED</span>
+          </Link>
+          <p>Molecular viewer</p>
+          <div className="nav-actions">
+            <Link href="/examples">Examples</Link>
+            <Link className="nav-github" href="/">
+              Project home
+            </Link>
+          </div>
+        </nav>
+      </header>
+
+      <main className="viewer-page" id="viewer-main">
+        <section className="viewer-intro shell" aria-labelledby="viewer-heading">
+          <div>
+            <p className="kicker">PyQED laboratory</p>
+            <h1 id="viewer-heading">See the geometry before you calculate.</h1>
+          </div>
+          <p>
+            Paste PyQED coordinates or open an XYZ file. Rotate, zoom, inspect
+            inferred bonds, and export a clean geometry for your next calculation.
+            Everything runs locally in your browser.
+          </p>
+        </section>
+
+        <MoleculeViewer />
+      </main>
+    </>
+  );
+}

--- a/website/tests/rendered-html.test.mjs
+++ b/website/tests/rendered-html.test.mjs
@@ -106,6 +106,21 @@ test("exports the release-pinned examples library", async () => {
   assert.doesNotMatch(html, /chatgpt\.site/i);
 });
 
+test("exports the interactive molecular viewer", async () => {
+  const html = await page("/viewer");
+  const viewerSource = await readFile(
+    new URL("app/viewer/molecule-viewer.tsx", projectRoot),
+    "utf8",
+  );
+
+  assert.match(html, /<title>Interactive Molecular Viewer \| PyQED<\/title>/i);
+  assert.match(html, /Interactive Molecular Viewer/i);
+  assert.match(html, /rel="canonical" href="https:\/\/pyqed\.org\/viewer\/?"/i);
+  assert.match(viewerSource, /window\.location\.hash/);
+  assert.match(viewerSource, /parameters\.get\("xyz"\)/);
+  assert.match(viewerSource, /representation/);
+});
+
 test("uses a static, repository-owned deployment", async () => {
   const [layout, copyButton, privacy, nextConfig, packageText, workflow] =
     await Promise.all([
@@ -132,6 +147,7 @@ test("uses a static, repository-owned deployment", async () => {
   for (const artifact of [
     "index.html",
     "examples/index.html",
+    "viewer/index.html",
     "privacy/index.html",
     "robots.txt",
     "sitemap.xml",


### PR DESCRIPTION
## What changed

- adds a static `/viewer/` molecular visualization workspace
- supports XYZ and PyQED atom strings, drag rotation, zoom, representations, labels, presets, and XYZ export
- loads molecules passed by `pyqed.view(mol)` through URL-fragment parameters
- adds Viewer navigation and sitemap coverage

## Why

`pyqed.view(mol)` opened `https://pyqed.org/viewer`, but the GitHub Pages source did not contain that route, so users received a 404.

## Validation

- Next.js static production build completed successfully and exported `/viewer`
- ESLint passed
- rendered static-site tests: 5 passed
- Python visualization tests: 8 passed