### PR TITLE
Remove duplicate Viewer navigation link

### DIFF
--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -295,7 +295,6 @@ export default function Home() {
           </div>
 
           <div className="nav-actions">
-            <Link href="/viewer">Viewer</Link>
             <a href={links.userGuide}>User Guide</a>
             <a className="nav-github" href={links.github}>
               GitHub <span aria-hidden="true">↗</span>
@@ -308,7 +307,6 @@ export default function Home() {
                     {label}
                   </a>
                 ))}
-                <Link href="/viewer">Viewer</Link>
                 <a href={links.userGuide}>User Guide</a>
                 <a href={links.docs}>Stable documentation</a>
               </nav>

--- a/website/tests/rendered-html.test.mjs
+++ b/website/tests/rendered-html.test.mjs
@@ -56,6 +56,13 @@ test("exports the research-first PyQED homepage", async () => {
   );
   assert.match(html, /href="\/examples\/?"[^>]*>Examples/i);
   assert.match(html, /href="\/viewer\/?"[^>]*>Viewer/i);
+  const header = html.match(/<header\b[\s\S]*?<\/header>/i)?.[0];
+  assert.ok(header, "homepage header should be rendered");
+  assert.equal(
+    (header.match(/href="\/viewer\/?"[^>]*>Viewer<\/a>/gi) ?? []).length,
+    2,
+    "render exactly one Viewer link in each desktop and mobile navigation",
+  );
 
   const workflows = section(html, "workflows");
   assert.equal((workflows.match(/data-workflow=/gi) ?? []).length, 4);


### PR DESCRIPTION
## What changed
- removed the redundant Viewer action from the desktop header
- removed the duplicate Viewer entry from the mobile menu
- retained one primary Viewer link in each navigation layout and the intentional footer link
- added a rendered-HTML regression assertion for the navigation count

## Root cause
The Viewer route was present in the shared primary navigation array and inserted again as an explicit action link.

## Validation
- `npm run lint`
- `npm test` (production static export plus all 8 rendered-HTML tests)