### PR TITLE
Add Hessian normal-mode visualization

### DIFF
--- a/pyqed/visualization.py
+++ b/pyqed/visualization.py
@@ -23,7 +23,7 @@ import webbrowser
 
 import numpy as np
 
-from pyqed.units import au2angstrom
+from pyqed.units import au2angstrom, au2wavenumber
 
 
 _VIEWER_URL = "https://pyqed.org/viewer"
@@ -457,6 +457,61 @@ def _viewer_origin(viewer_url: str) -> str:
     return origin
 
 
+@dataclass(frozen=True)
+class NormalModeAnimation:
+    """Browser-ready displacement data for one harmonic normal mode."""
+
+    mode_index: int
+    frequency_cm1: float
+    displacements: np.ndarray
+    amplitude_angstrom: float
+    frames: int = 24
+    interval: int = 60
+
+    def __post_init__(self) -> None:
+        mode_index = int(self.mode_index)
+        frequency = float(self.frequency_cm1)
+        displacements = np.array(self.displacements, dtype=float, copy=True)
+        amplitude = float(self.amplitude_angstrom)
+        frames = int(self.frames)
+        interval = int(self.interval)
+        if mode_index < 0:
+            raise ValueError("mode_index must be non-negative")
+        if not np.isfinite(frequency):
+            raise ValueError("frequency_cm1 must be finite")
+        if displacements.ndim != 2 or displacements.shape[1] != 3:
+            raise ValueError("normal-mode displacements must have shape (natom, 3)")
+        if not np.all(np.isfinite(displacements)):
+            raise ValueError("normal-mode displacements must be finite")
+        if not np.isfinite(amplitude) or amplitude <= 0.0 or amplitude > 10.0:
+            raise ValueError("amplitude_angstrom must be in the interval (0, 10]")
+        if frames < 8 or frames > 120:
+            raise ValueError("frames must be between 8 and 120")
+        if interval < 16 or interval > 1000:
+            raise ValueError("interval must be between 16 and 1000 milliseconds")
+        displacements.setflags(write=False)
+        object.__setattr__(self, "mode_index", mode_index)
+        object.__setattr__(self, "frequency_cm1", frequency)
+        object.__setattr__(self, "displacements", displacements)
+        object.__setattr__(self, "amplitude_angstrom", amplitude)
+        object.__setattr__(self, "frames", frames)
+        object.__setattr__(self, "interval", interval)
+
+    @property
+    def label(self) -> str:
+        return f"Mode {self.mode_index}: {self.frequency_cm1:.1f} cm^-1"
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "mode_index": self.mode_index,
+            "frequency_cm1": self.frequency_cm1,
+            "displacements": self.displacements.tolist(),
+            "amplitude_angstrom": self.amplitude_angstrom,
+            "frames": self.frames,
+            "interval": self.interval,
+        }
+
+
 @dataclass
 class SceneView:
     """A geometry and zero or more regular scalar fields for the web viewer."""
@@ -469,6 +524,7 @@ class SceneView:
     height: int = 640
     title: str | None = None
     active_field: str | int | None = None
+    vibration: NormalModeAnimation | None = None
     viewer_url: str = _VIEWER_URL
 
     def __post_init__(self) -> None:
@@ -522,6 +578,11 @@ class SceneView:
             raise ValueError("a scene must contain geometry or at least one scalar field")
         if self.xyz is not None:
             self.xyz = _validate_xyz_payload(self.xyz)
+        if self.vibration is not None:
+            if not isinstance(self.vibration, NormalModeAnimation):
+                raise TypeError("vibration must be a NormalModeAnimation")
+            if self.xyz is None:
+                raise ValueError("normal-mode animation requires molecular geometry")
         if self.title is not None:
             self.title = str(self.title).strip()
             if not self.title or len(self.title) > 160 or any(
@@ -538,7 +599,7 @@ class SceneView:
         deliberately absent from this property and is transported by
         :meth:`open` or :meth:`_repr_html_` using ``postMessage``.
         """
-        if self.fields:
+        if self.fields or self.vibration is not None:
             return self.viewer_url
         fragment = urlencode(
             {
@@ -563,6 +624,8 @@ class SceneView:
             "fields": [item.to_payload() for item in self.fields],
             "active_field": self.active_field,
         }
+        if self.vibration is not None:
+            scene["vibration"] = self.vibration.to_payload()
         if self.title:
             scene["title"] = self.title
         return scene
@@ -622,7 +685,7 @@ class SceneView:
 
     def open(self) -> bool:
         """Open the scene in the default browser."""
-        if not self.fields:
+        if not self.fields and self.vibration is None:
             return webbrowser.open_new_tab(self.url)
         handle = tempfile.NamedTemporaryFile(
             mode="w",
@@ -645,7 +708,7 @@ class SceneView:
 
     def _repr_html_(self) -> str:
         """Render the interactive viewer inline in a Jupyter frontend."""
-        if self.fields:
+        if self.fields or self.vibration is not None:
             return self._launcher_html(full_page=False)
         src = escape(self.url, quote=True)
         return (
@@ -678,6 +741,97 @@ def _molecule_from_object(obj):
         if candidate is not None and callable(getattr(candidate, "atom_coords", None)):
             return candidate
     raise TypeError("could not find molecular geometry on the supplied object")
+
+
+def _normal_mode_animation(
+    hessian,
+    molecule,
+    *,
+    mode,
+    amplitude,
+    coordinates_unit,
+    frames,
+    interval,
+) -> NormalModeAnimation:
+    analysis_method = getattr(hessian, "vibrational_analysis", None)
+    if not callable(analysis_method):
+        raise TypeError("mode viewing requires a completed Hessian object")
+    try:
+        analysis = analysis_method()
+    except ValueError as exc:
+        raise ValueError(
+            "run the Hessian calculation before calling view(hessian, mode=...)"
+        ) from exc
+    if not isinstance(analysis, Mapping):
+        raise TypeError("vibrational_analysis() must return a mapping")
+
+    raw_modes = analysis.get("modes", analysis.get("norm_mode"))
+    if raw_modes is None:
+        raise ValueError("vibrational analysis did not return normal modes")
+    modes = np.asarray(raw_modes, dtype=float)
+    if modes.ndim != 3 or modes.shape[2] != 3:
+        raise ValueError("normal modes must have shape (nmodes, natom, 3)")
+    if isinstance(mode, (bool, np.bool_)):
+        raise TypeError("mode must be an integer index")
+    mode_index = int(mode)
+    if mode_index != mode:
+        raise TypeError("mode must be an integer index")
+    if mode_index < 0 or mode_index >= modes.shape[0]:
+        raise IndexError(f"mode index {mode_index} is outside [0, {modes.shape[0]})")
+
+    coordinates = np.asarray(molecule.atom_coords(), dtype=float)
+    displacement = np.asarray(modes[mode_index], dtype=float)
+    if displacement.shape != coordinates.shape:
+        raise ValueError("normal-mode shape does not match the molecule")
+    if not np.all(np.isfinite(displacement)):
+        raise ValueError("normal-mode displacements must be finite")
+    maximum = float(np.max(np.linalg.norm(displacement, axis=1)))
+    if maximum <= np.finfo(float).eps:
+        raise ValueError("selected normal mode has zero displacement")
+
+    unit = str(coordinates_unit).lower()
+    if unit in {"bohr", "b", "au", "a.u."}:
+        coordinates_angstrom = coordinates * au2angstrom
+    elif unit in {"angstrom", "angstroms", "a", "å"}:
+        coordinates_angstrom = coordinates
+    else:
+        raise ValueError("coordinates_unit must be 'bohr' or 'angstrom'")
+    if amplitude == "auto":
+        span = float(np.max(np.ptp(coordinates_angstrom, axis=0)))
+        amplitude_angstrom = min(0.5, max(0.12, 0.18 * max(span, 1.0)))
+    else:
+        amplitude_angstrom = float(amplitude)
+        if (
+            not np.isfinite(amplitude_angstrom)
+            or amplitude_angstrom <= 0.0
+            or amplitude_angstrom > 10.0
+        ):
+            raise ValueError("amplitude must be 'auto' or a value in (0, 10] angstrom")
+    displacement_angstrom = displacement * (amplitude_angstrom / maximum)
+
+    if "freq_cm1" in analysis:
+        frequencies = analysis["freq_cm1"]
+    elif "freq_wavenumber" in analysis:
+        frequencies = analysis["freq_wavenumber"]
+    elif "freq_au" in analysis:
+        frequencies = np.asarray(analysis["freq_au"]) * au2wavenumber
+    else:
+        raise ValueError("vibrational analysis did not return frequencies")
+    frequencies = np.asarray(frequencies)
+    if frequencies.shape != (modes.shape[0],):
+        raise ValueError("vibrational frequencies do not match the normal modes")
+    frequency = np.real_if_close(frequencies[mode_index])
+    if np.iscomplexobj(frequency):
+        frequency = frequency.real - abs(frequency.imag)
+
+    return NormalModeAnimation(
+        mode_index=mode_index,
+        frequency_cm1=float(frequency),
+        displacements=displacement_angstrom,
+        amplitude_angstrom=amplitude_angstrom,
+        frames=frames,
+        interval=interval,
+    )
 
 
 def _scf_reference(obj):
@@ -1670,6 +1824,10 @@ def _read_cube(path: Path, *, dataset: int | str = 0):
 def view(
     obj,
     *,
+    mode: int | None = None,
+    amplitude: str | float = "auto",
+    frames: int = 24,
+    interval: int = 60,
     orbital=None,
     coeff=None,
     orbital_spin: str = "auto",
@@ -1701,7 +1859,8 @@ def view(
 
     Examples
     --------
-    ``view(mol)`` shows geometry.  For a converged SCF object, use
+    ``view(mol)`` shows geometry and ``view(hessian, mode=0)`` animates one
+    harmonic normal mode.  For a converged SCF object, use
     ``view(mf, orbital=['homo', 'lumo'])``, ``orbital='all'``,
     ``density='all'`` (including unrestricted spin density), or ``esp=True``.
     ``view(td, nto='all')`` builds NTO hole/particle layers for every exposed
@@ -1714,9 +1873,21 @@ def view(
     esp_requested = esp is not None and esp is not False
     density_requested = density is not None and density is not False
     nto_requested = nto is not None and nto is not False
+    mode_requested = mode is not None
+    if mode_requested and (
+        orbital is not None
+        or coeff is not None
+        or density_requested
+        or nto_requested
+        or fields is not None
+        or esp_requested
+    ):
+        raise ValueError("normal-mode animation cannot be combined with scalar fields")
     if isinstance(obj, SceneView):
         if (
-            orbital is not None
+            mode_requested
+            or amplitude != "auto"
+            or orbital is not None
             or coeff is not None
             or density_requested
             or nto_requested
@@ -1732,7 +1903,9 @@ def view(
         if path.suffix.lower() not in {".cube", ".cub"}:
             raise ValueError("view(path) currently accepts .cube and .cub files")
         if (
-            orbital is not None
+            mode_requested
+            or amplitude != "auto"
+            or orbital is not None
             or coeff is not None
             or density_requested
             or nto_requested
@@ -1754,6 +1927,17 @@ def view(
     else:
         molecule = _molecule_from_object(obj)
         xyz = _molecule_xyz(molecule, coordinates_unit=coordinates_unit)
+        vibration = None
+        if mode_requested:
+            vibration = _normal_mode_animation(
+                obj,
+                molecule,
+                mode=mode,
+                amplitude=amplitude,
+                coordinates_unit=coordinates_unit,
+                frames=frames,
+                interval=interval,
+            )
         external_fields: list[ScalarField3D] = []
         if fields is not None:
             if isinstance(fields, ScalarField3D):
@@ -1854,8 +2038,9 @@ def view(
             labels=bool(labels),
             width=width,
             height=height,
-            title=title,
+            title=title or (vibration.label if vibration is not None else None),
             active_field=active_field,
+            vibration=vibration,
         )
 
     should_open = not _in_notebook() if open_browser is None else bool(open_browser)

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -24,6 +24,17 @@ class TinyMolecule:
         return np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]])
 
 
+class TinyHessian:
+    mol = TinyMolecule()
+
+    def vibrational_analysis(self):
+        return {
+            "freq_cm1": np.array([1234.5]),
+            "modes": np.array([[[0.0, 0.0, -2.0], [0.0, 0.0, 1.0]]]),
+            "reduced_mass_amu": np.array([1.2]),
+        }
+
+
 def fragment_parameters(result):
     return parse_qs(urlsplit(result.url).fragment)
 
@@ -64,6 +75,47 @@ def test_view_provides_an_inline_notebook_representation():
     assert 'height="480"' in html
     assert "PyQED molecular viewer" in html
     assert "allow-scripts" in html
+
+
+def test_view_hessian_builds_browser_normal_mode_animation():
+    result = view(
+        TinyHessian(),
+        mode=0,
+        amplitude=0.25,
+        frames=32,
+        interval=45,
+        open_browser=False,
+    )
+
+    payload = result.payload()
+    vibration = payload["vibration"]
+    assert result.url == "https://pyqed.org/viewer"
+    assert result.title == "Mode 0: 1234.5 cm^-1"
+    assert vibration["mode_index"] == 0
+    assert vibration["frequency_cm1"] == pytest.approx(1234.5)
+    assert vibration["frames"] == 32
+    assert vibration["interval"] == 45
+    assert vibration["amplitude_angstrom"] == pytest.approx(0.25)
+    displacement = np.asarray(vibration["displacements"])
+    assert displacement.shape == (2, 3)
+    assert np.max(np.linalg.norm(displacement, axis=1)) == pytest.approx(0.25)
+    assert "postMessage" in result._repr_html_()
+
+
+def test_view_hessian_rejects_invalid_or_unavailable_modes():
+    with pytest.raises(IndexError, match="outside"):
+        view(TinyHessian(), mode=1, open_browser=False)
+    with pytest.raises(TypeError, match="integer"):
+        view(TinyHessian(), mode=True, open_browser=False)
+    with pytest.raises(TypeError, match="completed Hessian"):
+        view(TinyMolecule(), mode=0, open_browser=False)
+
+    class PendingHessian(TinyHessian):
+        def vibrational_analysis(self):
+            raise ValueError("run first")
+
+    with pytest.raises(ValueError, match="run the Hessian"):
+        view(PendingHessian(), mode=0, open_browser=False)
 
 
 def test_top_level_and_molecule_convenience_apis():

--- a/website/app/viewer/molecule-viewer.tsx
+++ b/website/app/viewer/molecule-viewer.tsx
@@ -30,8 +30,10 @@ import {
 type Bond = [number, number];
 type RenderMode = "ball-stick" | "space-fill" | "wireframe";
 type SurfaceMode = "both" | "positive" | "negative" | "esp-map" | "hidden";
+type Vibration = NonNullable<ValidatedScene["vibration"]>;
 
 type ViewerApi = {
+  animate(options: Record<string, unknown>): unknown;
   addIsosurface(data: unknown, options: Record<string, unknown>): unknown;
   addLabel(text: string, options: Record<string, unknown>): unknown;
   addModel(data: string, format: string): unknown;
@@ -50,6 +52,13 @@ type ViewerApi = {
   setStyle(selection: Record<string, never>, style: Record<string, unknown>): unknown;
   setView(view: number[]): unknown;
   spin(axis: string | false, speed?: number): unknown;
+  stopAnimate(): unknown;
+  vibrate(
+    frames: number,
+    amplitude: number,
+    bothWays: boolean,
+    arrowSpec?: Record<string, unknown>,
+  ): unknown;
   zoomTo(): unknown;
 };
 
@@ -204,6 +213,14 @@ function modelStyle(mode: RenderMode): Record<string, unknown> {
   };
 }
 
+function vibrationalXyz(atoms: Atom[], vibration: Vibration): string {
+  const rows = atoms.map((atom, index) => {
+    const [dx, dy, dz] = vibration.displacements[index];
+    return `${atom.element.padEnd(2)} ${atom.x.toFixed(10)} ${atom.y.toFixed(10)} ${atom.z.toFixed(10)} ${dx.toFixed(10)} ${dy.toFixed(10)} ${dz.toFixed(10)}`;
+  });
+  return `${atoms.length}\nMode ${vibration.modeIndex}: ${vibration.frequencyCm1.toFixed(3)} cm^-1\n${rows.join("\n")}\n`;
+}
+
 function MolecularFieldCanvas({
   atoms,
   fields,
@@ -214,6 +231,8 @@ function MolecularFieldCanvas({
   surfaceMode,
   isovalue,
   resetSignal,
+  vibration,
+  vibrationPlaying,
 }: {
   atoms: Atom[];
   fields: VolumeField[];
@@ -224,6 +243,8 @@ function MolecularFieldCanvas({
   surfaceMode: SurfaceMode;
   isovalue: number;
   resetSignal: number;
+  vibration: Vibration | null;
+  vibrationPlaying: boolean;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const viewerRef = useRef<ViewerApi | null>(null);
@@ -260,6 +281,7 @@ function MolecularFieldCanvas({
     return () => {
       cancelled = true;
       renderRevision.current += 1;
+      viewerRef.current?.stopAnimate();
       viewerRef.current?.spin(false);
       viewerRef.current = null;
       libraryRef.current = null;
@@ -274,14 +296,32 @@ function MolecularFieldCanvas({
     if (!viewer) return;
     const previousView = hasRendered.current ? viewer.getView() : null;
 
+    viewer.stopAnimate();
     viewer.removeAllLabels();
     viewer.removeAllModels();
     if (atoms.length > 0) {
-      viewer.addModel(xyzFor(atoms), "xyz");
+      viewer.addModel(
+        vibration ? vibrationalXyz(atoms, vibration) : xyzFor(atoms),
+        "xyz",
+      );
       viewer.setStyle({}, modelStyle(mode));
+      if (vibration) {
+        viewer.vibrate(vibration.frames, 1, true, {
+          color: "#35d6e3",
+          radius: 0.045,
+          radiusRatio: 1.7,
+        });
+        if (vibrationPlaying) {
+          viewer.animate({
+            interval: vibration.interval,
+            loop: "backAndForth",
+            reps: 0,
+          });
+        }
+      }
     }
 
-    if (labels && atoms.length > 0) {
+    if (labels && atoms.length > 0 && !vibration) {
       atoms.forEach((atom, index) => {
         viewer.addLabel(`${atom.element}${index + 1}`, {
           position: { x: atom.x, y: atom.y, z: atom.z },
@@ -300,7 +340,7 @@ function MolecularFieldCanvas({
     else if (previousView) viewer.setView(previousView);
     viewer.render();
     hasRendered.current = true;
-  }, [atoms, labels, mode, rendererStatus]);
+  }, [atoms, labels, mode, rendererStatus, vibration, vibrationPlaying]);
 
   useEffect(() => {
     if (rendererStatus !== "ready") return;
@@ -461,6 +501,8 @@ export function MoleculeViewer() {
   const [unit, setUnit] = useState<"angstrom" | "bohr">("angstrom");
   const [atoms, setAtoms] = useState<Atom[]>(() => parseGeometry(PRESETS.Water, "angstrom"));
   const [fields, setFields] = useState<VolumeField[]>([]);
+  const [vibration, setVibration] = useState<Vibration | null>(null);
+  const [vibrationPlaying, setVibrationPlaying] = useState(false);
   const [activeFieldIndex, setActiveFieldIndex] = useState(-1);
   const [surfaceMode, setSurfaceMode] = useState<SurfaceMode>("hidden");
   const [isovalue, setIsovalue] = useState(0.02);
@@ -513,9 +555,12 @@ export function MoleculeViewer() {
     setSource(scene.molecule?.xyz ?? "");
     setUnit("angstrom");
     setFields(scene.fields);
+    setVibration(scene.vibration);
+    setVibrationPlaying(scene.vibration !== null);
     setSceneTitle(scene.title);
     setMode(scene.molecule?.representation ?? "ball-stick");
     setLabels(scene.molecule?.labels ?? false);
+    if (scene.vibration) setAutoRotate(false);
     setError(null);
     setStatus(nextStatus);
     const nextField = scene.fields[scene.activeFieldIndex];
@@ -537,6 +582,8 @@ export function MoleculeViewer() {
         setSource(geometry);
         setUnit("angstrom");
         setFields([]);
+        setVibration(null);
+        setVibrationPlaying(false);
         setActiveFieldIndex(-1);
         setSurfaceMode("hidden");
         setSceneTitle("Linked geometry");
@@ -583,7 +630,9 @@ export function MoleculeViewer() {
         const scene = validateSceneMessage(event.data);
         applyScene(
           scene,
-          `${scene.fields.length} ${scene.fields.length === 1 ? "surface" : "states / surfaces"} received from PyQED`,
+          scene.vibration
+            ? `Normal mode ${scene.vibration.modeIndex} received from PyQED`
+            : `${scene.fields.length} ${scene.fields.length === 1 ? "surface" : "states / surfaces"} received from PyQED`,
         );
       } catch (sceneError) {
         setError(
@@ -618,6 +667,8 @@ export function MoleculeViewer() {
     try {
       setAtoms(parseGeometry(nextSource, nextUnit));
       setFields([]);
+      setVibration(null);
+      setVibrationPlaying(false);
       setActiveFieldIndex(-1);
       setSurfaceMode("hidden");
       setSceneTitle(nextTitle);
@@ -663,6 +714,8 @@ export function MoleculeViewer() {
         setUnit("angstrom");
         setAtoms(nextAtoms);
         setFields([]);
+        setVibration(null);
+        setVibrationPlaying(false);
         setActiveFieldIndex(-1);
         setSurfaceMode("hidden");
         setSceneTitle(file.name.replace(/\.xyz$/i, ""));
@@ -799,8 +852,14 @@ export function MoleculeViewer() {
       >
         <div className="viewer-toolbar">
           <div className="molecule-identity">
-            <span>{activeField ? FIELD_KIND_LABELS[activeField.kind] : "Live structure"}</span>
-            <strong>{activeField?.label ?? formula}</strong>
+            <span>
+              {vibration ? "Normal mode" : activeField ? FIELD_KIND_LABELS[activeField.kind] : "Live structure"}
+            </span>
+            <strong>
+              {vibration
+                ? `Mode ${vibration.modeIndex} · ${vibration.frequencyCm1.toFixed(1)} cm⁻¹`
+                : activeField?.label ?? formula}
+            </strong>
             <small>
               {sceneTitle} · {atoms.length} atoms · {bonds.length} inferred bonds
               {fields.length > 0 ? ` · ${fields.length} ${fields.length === 1 ? "surface" : "states / surfaces"}` : ""}
@@ -888,6 +947,16 @@ export function MoleculeViewer() {
             >
               Auto-rotate
             </button>
+            {vibration ? (
+              <button
+                type="button"
+                className={vibrationPlaying ? "is-active" : ""}
+                aria-pressed={vibrationPlaying}
+                onClick={() => setVibrationPlaying((value) => !value)}
+              >
+                {vibrationPlaying ? "Pause mode" : "Play mode"}
+              </button>
+            ) : null}
             <button type="button" onClick={() => setResetSignal((value) => value + 1)}>
               Reset view
             </button>
@@ -904,6 +973,8 @@ export function MoleculeViewer() {
           surfaceMode={surfaceMode}
           isovalue={renderedIsovalue}
           resetSignal={resetSignal}
+          vibration={vibration}
+          vibrationPlaying={vibrationPlaying}
         />
 
         {isDraggingFile ? (

--- a/website/app/viewer/volume-data.d.mts
+++ b/website/app/viewer/volume-data.d.mts
@@ -41,6 +41,14 @@ export type ValidatedScene = {
     representation: "ball-stick" | "space-fill" | "wireframe";
     labels: boolean;
   } | null;
+  vibration: {
+    modeIndex: number;
+    frequencyCm1: number;
+    displacements: [number, number, number][];
+    amplitudeAngstrom: number;
+    frames: number;
+    interval: number;
+  } | null;
   fields: VolumeField[];
   activeFieldIndex: number;
 };

--- a/website/app/viewer/volume-data.mjs
+++ b/website/app/viewer/volume-data.mjs
@@ -427,6 +427,53 @@ function validateField(rawField, index) {
   };
 }
 
+function validateVibration(rawVibration, atomCount) {
+  const context = "message.scene.vibration";
+  if (!isRecord(rawVibration)) fail(`${context} must be an object.`);
+  assertAllowedKeys(
+    rawVibration,
+    new Set([
+      "mode_index", "frequency_cm1", "displacements", "amplitude_angstrom",
+      "frames", "interval",
+    ]),
+    context,
+  );
+  const modeIndex = rawVibration.mode_index;
+  if (!Number.isSafeInteger(modeIndex) || modeIndex < 0) {
+    fail(`${context}.mode_index must be a non-negative integer.`);
+  }
+  const frequencyCm1 = finiteNumber(rawVibration.frequency_cm1, `${context}.frequency_cm1`);
+  const amplitudeAngstrom = finiteNumber(
+    rawVibration.amplitude_angstrom,
+    `${context}.amplitude_angstrom`,
+  );
+  if (amplitudeAngstrom <= 0 || amplitudeAngstrom > 10) {
+    fail(`${context}.amplitude_angstrom must be greater than zero and at most 10.`);
+  }
+  if (!Array.isArray(rawVibration.displacements) || rawVibration.displacements.length !== atomCount) {
+    fail(`${context}.displacements must contain one vector per atom.`);
+  }
+  const displacements = rawVibration.displacements.map((vector, index) =>
+    finiteVector(vector, `${context}.displacements[${index}]`),
+  );
+  const frames = rawVibration.frames;
+  if (!Number.isSafeInteger(frames) || frames < 8 || frames > 120) {
+    fail(`${context}.frames must be an integer between 8 and 120.`);
+  }
+  const interval = rawVibration.interval;
+  if (!Number.isSafeInteger(interval) || interval < 16 || interval > 1000) {
+    fail(`${context}.interval must be an integer between 16 and 1000 milliseconds.`);
+  }
+  return {
+    modeIndex,
+    frequencyCm1,
+    displacements,
+    amplitudeAngstrom,
+    frames,
+    interval,
+  };
+}
+
 export function validateSceneMessage(message) {
   if (!isRecord(message)) fail("The PyQED message must be an object.");
   assertAllowedKeys(message, new Set(["type", "scene"]), "message");
@@ -435,7 +482,7 @@ export function validateSceneMessage(message) {
   const scene = message.scene;
   assertAllowedKeys(
     scene,
-    new Set(["version", "kind", "title", "molecule", "fields", "active_field"]),
+    new Set(["version", "kind", "title", "molecule", "fields", "active_field", "vibration"]),
     "message.scene",
   );
   if (scene.version !== 1 || scene.kind !== "pyqed-scene") {
@@ -458,6 +505,12 @@ export function validateSceneMessage(message) {
     const labels = scene.molecule.labels ?? false;
     if (typeof labels !== "boolean") fail("message.scene.molecule.labels must be true or false.");
     molecule = { xyz, representation, labels };
+  }
+
+  let vibration = null;
+  if (scene.vibration !== undefined && scene.vibration !== null) {
+    if (!molecule) fail("message.scene.vibration requires a molecule.");
+    vibration = validateVibration(scene.vibration, atoms.length);
   }
 
   if (!Array.isArray(scene.fields) || scene.fields.length > MAX_FIELDS) {
@@ -508,6 +561,7 @@ export function validateSceneMessage(message) {
     title,
     atoms,
     molecule,
+    vibration,
     fields,
     activeFieldIndex,
   };
@@ -704,6 +758,7 @@ export function parseCube(text, options = {}) {
       representation: "ball-stick",
       labels: false,
     },
+    vibration: null,
     fields,
     activeFieldIndex: fields.length > 0 ? 0 : -1,
   };

--- a/website/tests/rendered-html.test.mjs
+++ b/website/tests/rendered-html.test.mjs
@@ -326,6 +326,56 @@ test("validates encoded scalar fields and ESP density mappings", () => {
   );
 });
 
+test("validates normal-mode scenes and atom-aligned displacements", () => {
+  const message = {
+    type: "pyqed:scene",
+    scene: {
+      version: 1,
+      kind: "pyqed-scene",
+      title: "Mode 0: 4401.2 cm^-1",
+      molecule: {
+        xyz: "2\nH2\nH 0 0 -0.37\nH 0 0 0.37",
+        representation: "ball-stick",
+        labels: false,
+      },
+      vibration: {
+        mode_index: 0,
+        frequency_cm1: 4401.2,
+        displacements: [[0, 0, -0.15], [0, 0, 0.15]],
+        amplitude_angstrom: 0.15,
+        frames: 24,
+        interval: 60,
+      },
+      fields: [],
+      active_field: null,
+    },
+  };
+
+  const scene = validateSceneMessage(message);
+  assert.equal(scene.vibration.modeIndex, 0);
+  assert.equal(scene.vibration.frequencyCm1, 4401.2);
+  assert.deepEqual(scene.vibration.displacements[1], [0, 0, 0.15]);
+  assert.equal(scene.vibration.frames, 24);
+
+  assert.throws(
+    () => validateSceneMessage({
+      ...message,
+      scene: {
+        ...message.scene,
+        vibration: { ...message.scene.vibration, displacements: [[0, 0, 0.1]] },
+      },
+    }),
+    /one vector per atom/i,
+  );
+  assert.throws(
+    () => validateSceneMessage({
+      ...message,
+      scene: { ...message.scene, molecule: null },
+    }),
+    /requires a molecule/i,
+  );
+});
+
 test("parses single and multi-state Gaussian cube files in C order", () => {
   const singleCube = `Water field
 MO test
@@ -408,6 +458,8 @@ test("uses a static, repository-owned deployment", async () => {
   assert.match(moleculeViewer, /validateSceneMessage\(event\.data\)/);
   assert.match(moleculeViewer, /import\("3dmol"\)/);
   assert.match(moleculeViewer, /pyqed:viewer-ready/);
+  assert.match(moleculeViewer, /viewer\.vibrate\(vibration\.frames/);
+  assert.match(moleculeViewer, /Pause mode/);
   assert.ok(
     moleculeViewer.indexOf('window.addEventListener("message", receiveScene)') <
       moleculeViewer.indexOf('type: "pyqed:viewer-ready"'),


### PR DESCRIPTION
Adds `view(hessian, mode=0)` support to the Python visualization API and animates Hessian normal-mode displacement vectors in the 3D web viewer.

Validation:
- `pytest tests/test_visualization.py -q`
- website viewer tests
- real native H₂ RHF Hessian scene generation