### PR TITLE
Speed up normal-mode playback

### DIFF
--- a/pyqed/visualization.py
+++ b/pyqed/visualization.py
@@ -466,7 +466,7 @@ class NormalModeAnimation:
     displacements: np.ndarray
     amplitude_angstrom: float
     frames: int = 24
-    interval: int = 60
+    interval: int = 30
 
     def __post_init__(self) -> None:
         mode_index = int(self.mode_index)
@@ -1827,7 +1827,7 @@ def view(
     mode: int | None = None,
     amplitude: str | float = "auto",
     frames: int = 24,
-    interval: int = 60,
+    interval: int = 30,
     orbital=None,
     coeff=None,
     orbital_spin: str = "auto",

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -78,6 +78,9 @@ def test_view_provides_an_inline_notebook_representation():
 
 
 def test_view_hessian_builds_browser_normal_mode_animation():
+    default_result = view(TinyHessian(), mode=0, open_browser=False)
+    assert default_result.payload()["vibration"]["interval"] == 30
+
     result = view(
         TinyHessian(),
         mode=0,


### PR DESCRIPTION
Reduces the default normal-mode frame interval from 60 ms to 30 ms, while preserving the `interval=` override.

Validation: `pytest tests/test_visualization.py -q` (22 passed).