### PR TITLE
Replace normal-mode viewer with all-mode controls

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -10,7 +10,7 @@ Run source-tree examples from the repository root with ``PYTHONPATH=.``.  The
 code shown here is included directly from the tracked files, so the web guide
 and executable examples stay synchronized.
 
-Three verified starting points
+Four verified starting points
 ------------------------------
 
 Native H2 restricted Hartree--Fock
@@ -33,6 +33,31 @@ Run it with:
 The final line is approximately ``RHF energy: -1.116759307396 Eh``.  See
 :doc:`quickstart` for the explanation and :doc:`qchem` before changing the
 molecule or electronic-structure method.
+
+H2O harmonic normal-mode viewer
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Use for:** calculating a native RHF Hessian and animating all three water
+normal modes. **Requirements:** the base PyQED installation; opening the
+interactive scene requires a browser that can reach ``https://pyqed.org``.
+**Typical runtime:** a few seconds on a laptop. PySCF is not required.
+
+.. literalinclude:: ../../examples/qchem/h2o_normal_modes_viewer.py
+   :language: python
+   :linenos:
+
+Run it with:
+
+.. code-block:: bash
+
+   PYTHONPATH=. python examples/qchem/h2o_normal_modes_viewer.py
+
+For a terminal or continuous-integration smoke run, add ``--no-browser``. The
+example prints the signed harmonic frequencies and still validates the viewer
+scene without opening a window. It uses a geometry optimized at the same
+RHF/STO-3G level. These frequencies illustrate the API; they are not benchmark
+spectroscopic predictions. See :doc:`hf_analysis` for the mode-animation
+conventions and Hessian backend constraints.
 
 Sine-DVR harmonic oscillator
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/hf_analysis.rst
+++ b/docs/source/hf_analysis.rst
@@ -60,6 +60,46 @@ page URL: PyQED writes a local launcher and transfers validated float32 field
 data directly to the viewer. The website renders it locally in the browser
 and offers a field/state menu plus adjustable isovalues.
 
+Normal Modes
+------------
+
+A completed RHF Hessian can be sent to the same viewer. Keep the Hessian
+object itself: ``run()`` returns its Cartesian Hessian array, while the object
+retains that Hessian and the molecular geometry. The viewer derives the
+harmonic analysis from the stored Hessian without rerunning it.
+
+.. code-block:: python
+
+   from pyqed import view
+
+   hess = mf.Hessian()
+   hess.run()
+   view(hess, normal_modes="all")
+
+This call does not silently calculate a Hessian. The Hessian must already have
+been run; the viewer then calls ``vibrational_analysis()`` on the stored
+Cartesian Hessian. For the native RHF implementation, use the exact built-in
+J/K path, such as a molecule built with ``driver="builtin", eri="s8"``;
+density fitting, RI, low-rank J/K, and Cholesky J/K are not supported by that
+Hessian.
+
+Normal-mode scenes animate the reference geometry only. The amplitude control
+uses a normalized visual scale so the relative atomic displacements are clear;
+the accepted range is 0.01--10 Angstrom. It is not a physical normal-coordinate
+amplitude or a time-dependent nuclear trajectory. Frequencies retain their
+sign, and a negative frequency marks an imaginary mode. The sign of an
+individual displacement vector is arbitrary.
+Pause playback to scrub the phase between the two turning points or return to
+the reference geometry before exporting the displayed structure as XYZ.
+Raw mappings and completed IR-like objects must provide Cartesian atomic
+displacements with shape ``(nmodes, natom, 3)``, not mass-weighted
+eigenvectors; the viewer rescales each mode by one global factor.
+
+Reference-geometry molecular orbitals or density fields are intentionally not
+shown at the same time as a moving geometry, because stretching a fixed scalar
+field would be misleading. To inspect a field at a displaced structure, build
+that geometry and rerun the electronic-structure calculation.
+
 Basic Usage
 -----------
 

--- a/examples/qchem/h2o_normal_modes_viewer.py
+++ b/examples/qchem/h2o_normal_modes_viewer.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Calculate and animate the harmonic normal modes of a small water model."""
+
+import argparse
+
+from pyqed import view
+from pyqed.qchem import Molecule
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--no-browser",
+        action="store_true",
+        help="build and validate the viewer scene without opening a browser",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    mol = Molecule(
+        atom=(
+            "O 0 0 0; "
+            "H 0 -1.43256502 1.20149209; "
+            "H 0 1.43256502 1.20149209"
+        ),
+        unit="bohr",
+        basis="sto-3g",
+    )
+    # This geometry was optimized at RHF/STO-3G. The native analytic Hessian
+    # requires the exact built-in J/K path.
+    mol.build(driver="builtin", eri="s8")
+    mf = mol.RHF().run()
+
+    # Keep the Hessian object: run() itself returns the Cartesian Hessian array.
+    hess = mf.Hessian()
+    hess.run()
+    vibration = hess.vibrational_analysis()
+
+    print("Harmonic frequencies (cm^-1; negative means imaginary):")
+    for mode_index, frequency in enumerate(vibration["freq_cm1"], start=1):
+        print(f"  mode {mode_index}: {frequency: .2f}")
+
+    view(
+        hess,
+        normal_modes="all",
+        title="H2O harmonic normal modes",
+        open_browser=not args.no_browser,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/pyqed/__init__.py
+++ b/pyqed/__init__.py
@@ -11,7 +11,7 @@ from importlib import import_module
 
 import numpy as np
 
-from ._version import __version__
+from ._version import __version__ as __version__
 from .units import *  # noqa: F401,F403
 
 
@@ -34,6 +34,7 @@ def is_positive_def(a):
 _LAZY_ATTRS = {
     "view": ("pyqed.visualization", "view"),
     "MoleculeView": ("pyqed.visualization", "MoleculeView"),
+    "NormalMode": ("pyqed.visualization", "NormalMode"),
     "ScalarField3D": ("pyqed.visualization", "ScalarField3D"),
     "SceneView": ("pyqed.visualization", "SceneView"),
     "VolumeView": ("pyqed.visualization", "VolumeView"),

--- a/pyqed/visualization.py
+++ b/pyqed/visualization.py
@@ -13,6 +13,7 @@ import base64
 from dataclasses import dataclass, field
 from html import escape
 import json
+from numbers import Integral
 from pathlib import Path
 import re
 import tempfile
@@ -32,13 +33,18 @@ _SCENE_KIND = "pyqed-scene"
 _SCENE_VERSION = 1
 _MAX_ATOMS = 500
 _MAX_FIELDS = 512
+_MAX_NORMAL_MODES = 512
 _MAX_AXIS_SIZE = 2048
 _MAX_FIELD_POINTS = 2_000_000
 _MAX_SCENE_POINTS = 8_000_000
+_MAX_MODE_COMPONENTS = _MAX_NORMAL_MODES * _MAX_ATOMS * 3
 _MAX_SERIALIZED_BYTES = 64_000_000
 _MAX_CUBE_BYTES = 80_000_000
 _MAX_GEOMETRY_CHARS = 1_000_000
 _MAX_FLOAT32 = float(np.finfo(np.float32).max)
+_MAX_SAFE_INTEGER = (1 << 53) - 1
+_MIN_MODE_AMPLITUDE_ANGSTROM = 0.01
+_MAX_MODE_AMPLITUDE_ANGSTROM = 10.0
 _COLOR_PATTERN = re.compile(
     r"^(?:#[0-9a-f]{3}|#[0-9a-f]{6}|#[0-9a-f]{8}|[a-z][a-z0-9_-]{0,31})$",
     re.IGNORECASE,
@@ -167,15 +173,28 @@ def _validate_xyz_payload(xyz: str) -> str:
     return xyz
 
 
-def _xyz_from_arrays(symbols, coordinates_angstrom) -> str:
+def _xyz_atom_count(xyz: str) -> int:
+    """Return the atom count from an already validated XYZ payload."""
+    raw_lines = [line.strip() for line in xyz.strip().splitlines()]
+    if raw_lines[0].isdigit():
+        return int(raw_lines[0])
+    return sum(
+        1
+        for line in raw_lines
+        for row in line.split(";")
+        if row.strip()
+    )
+
+
+def _xyz_from_arrays(symbols, coordinates, *, coordinates_unit: str = "angstrom") -> str:
     class _ArrayMolecule:
         def atom_symbols(self):
             return symbols
 
         def atom_coords(self):
-            return coordinates_angstrom
+            return coordinates
 
-    return _molecule_xyz(_ArrayMolecule(), coordinates_unit="angstrom")
+    return _molecule_xyz(_ArrayMolecule(), coordinates_unit=coordinates_unit)
 
 
 def _in_notebook() -> bool:
@@ -303,6 +322,148 @@ def _metadata_payload(value):
     if isinstance(value, tuple):
         return [_metadata_payload(entry) for entry in value]
     return value
+
+
+def _clean_line_text(value, *, name: str, maximum: int) -> str:
+    text = str(value).strip()
+    if not text or len(text) > maximum or any(
+        ord(character) < 32 or ord(character) == 127 for character in text
+    ):
+        raise ValueError(
+            f"{name} must fit on one line and contain at most {maximum} characters"
+        )
+    return text
+
+
+@dataclass(frozen=True)
+class NormalMode:
+    """One normalized Cartesian displacement pattern for the web viewer.
+
+    ``displacements`` has shape ``(natom, 3)``.  Its overall normalization is
+    arbitrary in harmonic analysis, so the stored vectors are rescaled such
+    that the largest per-atom norm is one.  :class:`SceneView` supplies the
+    visual display amplitude separately in Angstrom.
+    """
+
+    name: str
+    displacements: np.ndarray
+    frequency_cm1: float
+    label: str | None = None
+    reduced_mass_amu: float | None = None
+    intensity: float | None = None
+    intensity_unit: str | None = None
+    source_index: int | None = None
+
+    def __post_init__(self) -> None:
+        name = _clean_line_text(self.name, name="normal-mode name", maximum=80)
+        label = name if self.label is None else _clean_line_text(
+            self.label,
+            name="normal-mode label",
+            maximum=120,
+        )
+        displacements = _real_array(
+            self.displacements,
+            name=f"normal mode {name!r} displacements",
+        )
+        if (
+            displacements.ndim != 2
+            or displacements.shape[1:] != (3,)
+            or not 1 <= displacements.shape[0] <= _MAX_ATOMS
+        ):
+            raise ValueError(
+                "normal-mode displacements must have shape (natom, 3) with "
+                f"1 <= natom <= {_MAX_ATOMS}"
+            )
+        if np.max(np.abs(displacements), initial=0.0) > _MAX_FLOAT32:
+            raise ValueError("normal-mode displacements must fit in float32")
+        maximum_norm = float(np.max(np.linalg.norm(displacements, axis=1)))
+        if maximum_norm <= np.finfo(np.float32).tiny:
+            raise ValueError("normal-mode displacements cannot all be zero")
+        displacements = np.asarray(displacements / maximum_norm, dtype=np.float32)
+        displacements.setflags(write=False)
+
+        frequency = float(self.frequency_cm1)
+        if not np.isfinite(frequency) or abs(frequency) > _MAX_FLOAT32:
+            raise ValueError("frequency_cm1 must be a finite 32-bit value")
+
+        reduced_mass = self.reduced_mass_amu
+        if reduced_mass is not None:
+            reduced_mass = float(reduced_mass)
+            if (
+                not np.isfinite(reduced_mass)
+                or reduced_mass <= 0.0
+                or reduced_mass > _MAX_FLOAT32
+            ):
+                raise ValueError("reduced_mass_amu must be positive and finite")
+
+        intensity = self.intensity
+        if intensity is not None:
+            intensity = float(intensity)
+            if (
+                not np.isfinite(intensity)
+                or intensity < 0.0
+                or intensity > _MAX_FLOAT32
+            ):
+                raise ValueError("normal-mode intensity must be non-negative and finite")
+        intensity_unit = self.intensity_unit
+        if intensity_unit is not None:
+            if intensity is None:
+                raise ValueError("intensity_unit requires an intensity")
+            intensity_unit = _clean_line_text(
+                intensity_unit,
+                name="normal-mode intensity unit",
+                maximum=40,
+            )
+
+        source_index = self.source_index
+        if source_index is not None:
+            if isinstance(source_index, (bool, np.bool_)) or not isinstance(
+                source_index,
+                Integral,
+            ):
+                raise TypeError("source_index must be a non-negative integer")
+            integer = int(source_index)
+            if integer < 0 or integer > _MAX_SAFE_INTEGER:
+                raise ValueError(
+                    "source_index must be a non-negative JavaScript-safe integer"
+                )
+            source_index = integer
+
+        object.__setattr__(self, "name", name)
+        object.__setattr__(self, "label", label)
+        object.__setattr__(self, "displacements", displacements)
+        object.__setattr__(self, "frequency_cm1", frequency)
+        object.__setattr__(self, "reduced_mass_amu", reduced_mass)
+        object.__setattr__(self, "intensity", intensity)
+        object.__setattr__(self, "intensity_unit", intensity_unit)
+        object.__setattr__(self, "source_index", source_index)
+
+    @property
+    def shape(self) -> tuple[int, int]:
+        return tuple(int(size) for size in self.displacements.shape)
+
+    def to_payload(self) -> dict[str, Any]:
+        encoded = base64.b64encode(
+            np.asarray(self.displacements, dtype="<f4").ravel(order="C").tobytes()
+        ).decode("ascii")
+        payload: dict[str, Any] = {
+            "name": self.name,
+            "label": self.label,
+            "frequency_cm1": self.frequency_cm1,
+            "shape": list(self.shape),
+            "displacements": encoded,
+            "displacement_encoding": "float32-le-base64",
+            "normalization": "max-atom-displacement",
+        }
+        if self.reduced_mass_amu is not None:
+            payload["reduced_mass_amu"] = self.reduced_mass_amu
+        if self.intensity is not None:
+            payload["intensity"] = self.intensity
+        if self.intensity_unit is not None:
+            payload["intensity_unit"] = self.intensity_unit
+        if self.source_index is not None:
+            payload["source_index"] = self.source_index
+        return payload
 
 
 @dataclass(frozen=True)
@@ -457,74 +618,21 @@ def _viewer_origin(viewer_url: str) -> str:
     return origin
 
 
-@dataclass(frozen=True)
-class NormalModeAnimation:
-    """Browser-ready displacement data for one harmonic normal mode."""
-
-    mode_index: int
-    frequency_cm1: float
-    displacements: np.ndarray
-    amplitude_angstrom: float
-    frames: int = 24
-    interval: int = 30
-
-    def __post_init__(self) -> None:
-        mode_index = int(self.mode_index)
-        frequency = float(self.frequency_cm1)
-        displacements = np.array(self.displacements, dtype=float, copy=True)
-        amplitude = float(self.amplitude_angstrom)
-        frames = int(self.frames)
-        interval = int(self.interval)
-        if mode_index < 0:
-            raise ValueError("mode_index must be non-negative")
-        if not np.isfinite(frequency):
-            raise ValueError("frequency_cm1 must be finite")
-        if displacements.ndim != 2 or displacements.shape[1] != 3:
-            raise ValueError("normal-mode displacements must have shape (natom, 3)")
-        if not np.all(np.isfinite(displacements)):
-            raise ValueError("normal-mode displacements must be finite")
-        if not np.isfinite(amplitude) or amplitude <= 0.0 or amplitude > 10.0:
-            raise ValueError("amplitude_angstrom must be in the interval (0, 10]")
-        if frames < 8 or frames > 120:
-            raise ValueError("frames must be between 8 and 120")
-        if interval < 16 or interval > 1000:
-            raise ValueError("interval must be between 16 and 1000 milliseconds")
-        displacements.setflags(write=False)
-        object.__setattr__(self, "mode_index", mode_index)
-        object.__setattr__(self, "frequency_cm1", frequency)
-        object.__setattr__(self, "displacements", displacements)
-        object.__setattr__(self, "amplitude_angstrom", amplitude)
-        object.__setattr__(self, "frames", frames)
-        object.__setattr__(self, "interval", interval)
-
-    @property
-    def label(self) -> str:
-        return f"Mode {self.mode_index}: {self.frequency_cm1:.1f} cm^-1"
-
-    def to_payload(self) -> dict[str, Any]:
-        return {
-            "mode_index": self.mode_index,
-            "frequency_cm1": self.frequency_cm1,
-            "displacements": self.displacements.tolist(),
-            "amplitude_angstrom": self.amplitude_angstrom,
-            "frames": self.frames,
-            "interval": self.interval,
-        }
-
-
 @dataclass
 class SceneView:
-    """A geometry and zero or more regular scalar fields for the web viewer."""
+    """A geometry with optional scalar fields or normal modes."""
 
     xyz: str | None = None
     fields: tuple[ScalarField3D, ...] = ()
+    normal_modes: tuple[NormalMode, ...] = ()
     representation: str = "ball-stick"
     labels: bool = False
     width: int = 900
     height: int = 640
     title: str | None = None
     active_field: str | int | None = None
-    vibration: NormalModeAnimation | None = None
+    active_mode: str | int | None = None
+    mode_amplitude: float = 0.25
     viewer_url: str = _VIEWER_URL
 
     def __post_init__(self) -> None:
@@ -541,6 +649,19 @@ class SceneView:
             raise ValueError(f"a scene can contain at most {_MAX_FIELDS} fields")
         if sum(item.values.size for item in self.fields) > _MAX_SCENE_POINTS:
             raise ValueError(f"scene exceeds the {_MAX_SCENE_POINTS:,}-point limit")
+        self.normal_modes = tuple(self.normal_modes)
+        if any(not isinstance(item, NormalMode) for item in self.normal_modes):
+            raise TypeError("normal_modes must contain NormalMode objects")
+        if len(self.normal_modes) > _MAX_NORMAL_MODES:
+            raise ValueError(
+                f"a scene can contain at most {_MAX_NORMAL_MODES} normal modes"
+            )
+        if sum(item.displacements.size for item in self.normal_modes) > _MAX_MODE_COMPONENTS:
+            raise ValueError(
+                f"normal modes exceed the {_MAX_MODE_COMPONENTS:,}-component limit"
+            )
+        if self.fields and self.normal_modes:
+            raise ValueError("normal modes cannot be combined with scalar fields")
         names = [item.name for item in self.fields]
         if len(names) != len(set(names)):
             raise ValueError("field names must be unique within a scene")
@@ -574,15 +695,53 @@ class SceneView:
                 self.active_field = index
         elif self.fields:
             self.active_field = self.fields[0].name
+        mode_names = [item.name for item in self.normal_modes]
+        if len(mode_names) != len(set(mode_names)):
+            raise ValueError("normal-mode names must be unique within a scene")
+        if self.active_mode is not None:
+            if isinstance(self.active_mode, str):
+                if self.active_mode not in mode_names:
+                    raise ValueError(
+                        f"active_mode {self.active_mode!r} is not in the scene"
+                    )
+            else:
+                if isinstance(self.active_mode, (bool, np.bool_)) or not isinstance(
+                    self.active_mode,
+                    Integral,
+                ):
+                    raise TypeError("active_mode must be a mode name or integer index")
+                index = int(self.active_mode)
+                if index < 0 or index >= len(self.normal_modes):
+                    raise IndexError("active_mode index is out of range")
+                self.active_mode = self.normal_modes[index].name
+        elif self.normal_modes:
+            self.active_mode = self.normal_modes[0].name
+        if isinstance(self.mode_amplitude, (bool, np.bool_)):
+            raise TypeError("mode_amplitude must be a positive number in Angstrom")
+        self.mode_amplitude = float(self.mode_amplitude)
+        if (
+            not np.isfinite(self.mode_amplitude)
+            or not _MIN_MODE_AMPLITUDE_ANGSTROM
+            <= self.mode_amplitude
+            <= _MAX_MODE_AMPLITUDE_ANGSTROM
+        ):
+            raise ValueError(
+                "mode_amplitude must lie in ["
+                f"{_MIN_MODE_AMPLITUDE_ANGSTROM:g}, "
+                f"{_MAX_MODE_AMPLITUDE_ANGSTROM:g}] Angstrom"
+            )
+        if self.normal_modes and self.xyz is None:
+            raise ValueError("normal modes require molecular geometry")
         if self.xyz is None and not self.fields:
             raise ValueError("a scene must contain geometry or at least one scalar field")
         if self.xyz is not None:
             self.xyz = _validate_xyz_payload(self.xyz)
-        if self.vibration is not None:
-            if not isinstance(self.vibration, NormalModeAnimation):
-                raise TypeError("vibration must be a NormalModeAnimation")
-            if self.xyz is None:
-                raise ValueError("normal-mode animation requires molecular geometry")
+        if self.normal_modes:
+            atom_count = _xyz_atom_count(self.xyz)
+            if any(item.shape != (atom_count, 3) for item in self.normal_modes):
+                raise ValueError(
+                    "each normal mode must contain one displacement vector per atom"
+                )
         if self.title is not None:
             self.title = str(self.title).strip()
             if not self.title or len(self.title) > 160 or any(
@@ -595,11 +754,11 @@ class SceneView:
     def url(self) -> str:
         """Return the direct viewer URL.
 
-        Only geometry-only scenes use the legacy fragment.  Volumetric data is
-        deliberately absent from this property and is transported by
+        Only geometry-only scenes use the legacy fragment.  Volumetric and
+        normal-mode data is deliberately absent here and is transported by
         :meth:`open` or :meth:`_repr_html_` using ``postMessage``.
         """
-        if self.fields or self.vibration is not None:
+        if self.fields or self.normal_modes:
             return self.viewer_url
         fragment = urlencode(
             {
@@ -624,10 +783,14 @@ class SceneView:
             "fields": [item.to_payload() for item in self.fields],
             "active_field": self.active_field,
         }
-        if self.vibration is not None:
-            scene["vibration"] = self.vibration.to_payload()
         if self.title:
             scene["title"] = self.title
+        if self.normal_modes:
+            scene["normal_modes"] = {
+                "modes": [item.to_payload() for item in self.normal_modes],
+                "active_mode": self.active_mode,
+                "amplitude_angstrom": self.mode_amplitude,
+            }
         return scene
 
     def _encoded_payload(self) -> str:
@@ -685,7 +848,7 @@ class SceneView:
 
     def open(self) -> bool:
         """Open the scene in the default browser."""
-        if not self.fields and self.vibration is None:
+        if not self.fields and not self.normal_modes:
             return webbrowser.open_new_tab(self.url)
         handle = tempfile.NamedTemporaryFile(
             mode="w",
@@ -708,7 +871,7 @@ class SceneView:
 
     def _repr_html_(self) -> str:
         """Render the interactive viewer inline in a Jupyter frontend."""
-        if self.fields or self.vibration is not None:
+        if self.fields or self.normal_modes:
             return self._launcher_html(full_page=False)
         src = escape(self.url, quote=True)
         return (
@@ -741,97 +904,6 @@ def _molecule_from_object(obj):
         if candidate is not None and callable(getattr(candidate, "atom_coords", None)):
             return candidate
     raise TypeError("could not find molecular geometry on the supplied object")
-
-
-def _normal_mode_animation(
-    hessian,
-    molecule,
-    *,
-    mode,
-    amplitude,
-    coordinates_unit,
-    frames,
-    interval,
-) -> NormalModeAnimation:
-    analysis_method = getattr(hessian, "vibrational_analysis", None)
-    if not callable(analysis_method):
-        raise TypeError("mode viewing requires a completed Hessian object")
-    try:
-        analysis = analysis_method()
-    except ValueError as exc:
-        raise ValueError(
-            "run the Hessian calculation before calling view(hessian, mode=...)"
-        ) from exc
-    if not isinstance(analysis, Mapping):
-        raise TypeError("vibrational_analysis() must return a mapping")
-
-    raw_modes = analysis.get("modes", analysis.get("norm_mode"))
-    if raw_modes is None:
-        raise ValueError("vibrational analysis did not return normal modes")
-    modes = np.asarray(raw_modes, dtype=float)
-    if modes.ndim != 3 or modes.shape[2] != 3:
-        raise ValueError("normal modes must have shape (nmodes, natom, 3)")
-    if isinstance(mode, (bool, np.bool_)):
-        raise TypeError("mode must be an integer index")
-    mode_index = int(mode)
-    if mode_index != mode:
-        raise TypeError("mode must be an integer index")
-    if mode_index < 0 or mode_index >= modes.shape[0]:
-        raise IndexError(f"mode index {mode_index} is outside [0, {modes.shape[0]})")
-
-    coordinates = np.asarray(molecule.atom_coords(), dtype=float)
-    displacement = np.asarray(modes[mode_index], dtype=float)
-    if displacement.shape != coordinates.shape:
-        raise ValueError("normal-mode shape does not match the molecule")
-    if not np.all(np.isfinite(displacement)):
-        raise ValueError("normal-mode displacements must be finite")
-    maximum = float(np.max(np.linalg.norm(displacement, axis=1)))
-    if maximum <= np.finfo(float).eps:
-        raise ValueError("selected normal mode has zero displacement")
-
-    unit = str(coordinates_unit).lower()
-    if unit in {"bohr", "b", "au", "a.u."}:
-        coordinates_angstrom = coordinates * au2angstrom
-    elif unit in {"angstrom", "angstroms", "a", "å"}:
-        coordinates_angstrom = coordinates
-    else:
-        raise ValueError("coordinates_unit must be 'bohr' or 'angstrom'")
-    if amplitude == "auto":
-        span = float(np.max(np.ptp(coordinates_angstrom, axis=0)))
-        amplitude_angstrom = min(0.5, max(0.12, 0.18 * max(span, 1.0)))
-    else:
-        amplitude_angstrom = float(amplitude)
-        if (
-            not np.isfinite(amplitude_angstrom)
-            or amplitude_angstrom <= 0.0
-            or amplitude_angstrom > 10.0
-        ):
-            raise ValueError("amplitude must be 'auto' or a value in (0, 10] angstrom")
-    displacement_angstrom = displacement * (amplitude_angstrom / maximum)
-
-    if "freq_cm1" in analysis:
-        frequencies = analysis["freq_cm1"]
-    elif "freq_wavenumber" in analysis:
-        frequencies = analysis["freq_wavenumber"]
-    elif "freq_au" in analysis:
-        frequencies = np.asarray(analysis["freq_au"]) * au2wavenumber
-    else:
-        raise ValueError("vibrational analysis did not return frequencies")
-    frequencies = np.asarray(frequencies)
-    if frequencies.shape != (modes.shape[0],):
-        raise ValueError("vibrational frequencies do not match the normal modes")
-    frequency = np.real_if_close(frequencies[mode_index])
-    if np.iscomplexobj(frequency):
-        frequency = frequency.real - abs(frequency.imag)
-
-    return NormalModeAnimation(
-        mode_index=mode_index,
-        frequency_cm1=float(frequency),
-        displacements=displacement_angstrom,
-        amplitude_angstrom=amplitude_angstrom,
-        frames=frames,
-        interval=interval,
-    )
 
 
 def _scf_reference(obj):
@@ -1677,6 +1749,314 @@ def _nto_fields(
     return result
 
 
+def _mapping_first(data: Mapping[str, Any], names: tuple[str, ...]):
+    for name in names:
+        if name in data and data[name] is not None:
+            return data[name]
+    return None
+
+
+def _normal_mode_source_mapping(obj, *, _seen=None) -> Mapping[str, Any]:
+    """Return harmonic-analysis arrays without triggering a new calculation."""
+    if isinstance(obj, Mapping):
+        return obj
+
+    if _seen is None:
+        _seen = set()
+    marker = id(obj)
+    if marker in _seen:
+        raise TypeError("normal-mode source references itself")
+    _seen.add(marker)
+
+    public_frequencies = getattr(obj, "frequencies", None)
+    public_modes = getattr(obj, "modes", None)
+    if public_modes is None:
+        candidate = getattr(obj, "normal_modes", None)
+        if not callable(candidate):
+            public_modes = candidate
+    if (
+        public_frequencies is not None
+        and not callable(public_frequencies)
+        and public_modes is not None
+        and not callable(public_modes)
+    ):
+        return {
+            "frequencies": public_frequencies,
+            "modes": public_modes,
+            "reduced_mass_amu": getattr(
+                obj,
+                "reduced_masses",
+                getattr(obj, "reduced_mass", None),
+            ),
+            "intensities": getattr(obj, "intensities", None),
+            "frequency_unit": getattr(obj, "frequency_unit", "cm^-1"),
+            "intensity_unit": getattr(obj, "intensity_unit", None),
+        }
+
+    private_frequencies = getattr(obj, "_frequencies", None)
+    private_modes = getattr(obj, "_modes", None)
+    if private_frequencies is not None and private_modes is not None:
+        return {
+            "frequencies": private_frequencies,
+            "modes": private_modes,
+            "reduced_mass_amu": getattr(obj, "_reduced_masses", None),
+            "intensities": getattr(obj, "_intensities", None),
+            "frequency_unit": getattr(obj, "frequency_unit", "cm^-1"),
+            "intensity_unit": getattr(obj, "intensity_unit", None),
+        }
+
+    analysis = getattr(obj, "vibrational_analysis", None)
+    if callable(analysis):
+        data = analysis()
+        if not isinstance(data, Mapping):
+            raise TypeError("vibrational_analysis() must return a mapping")
+        return data
+
+    backend = getattr(obj, "backend", None)
+    if backend is not None:
+        return _normal_mode_source_mapping(backend, _seen=_seen)
+
+    raise TypeError(
+        "normal_modes requires completed harmonic data, an IR object, or a "
+        "completed Hessian with vibrational_analysis()"
+    )
+
+
+def _signed_frequency_array(values, *, name: str) -> np.ndarray:
+    try:
+        array = np.asarray(values, dtype=complex)
+    except (TypeError, ValueError) as exc:
+        raise TypeError(f"{name} must contain numeric values") from exc
+    if array.ndim != 1:
+        raise ValueError(f"{name} must be one-dimensional")
+    real = array.real
+    imaginary = array.imag
+    scale = np.maximum(1.0, np.maximum(np.abs(real), np.abs(imaginary)))
+    real_frequency = np.abs(imaginary) <= 1.0e-10 * scale
+    imaginary_frequency = np.abs(real) <= 1.0e-10 * scale
+    if np.any(~(real_frequency | imaginary_frequency)):
+        raise ValueError(
+            f"{name} may contain real or purely imaginary frequencies, not mixed values"
+        )
+    result = np.where(real_frequency, real, -np.abs(imaginary)).astype(float)
+    if not np.all(np.isfinite(result)) or np.max(np.abs(result), initial=0.0) > _MAX_FLOAT32:
+        raise ValueError(f"{name} must contain finite 32-bit values")
+    return result
+
+
+def _frequencies_cm1(data: Mapping[str, Any]) -> np.ndarray:
+    if "freq_cm1" in data and data["freq_cm1"] is not None:
+        return _signed_frequency_array(data["freq_cm1"], name="freq_cm1")
+    if "freq_wavenumber" in data and data["freq_wavenumber"] is not None:
+        return _signed_frequency_array(
+            data["freq_wavenumber"],
+            name="freq_wavenumber",
+        )
+    if "freq_au" in data and data["freq_au"] is not None:
+        values = _signed_frequency_array(data["freq_au"], name="freq_au")
+        converted = values * au2wavenumber
+        if np.max(np.abs(converted), initial=0.0) > _MAX_FLOAT32:
+            raise ValueError("converted frequencies must fit in float32")
+        return converted
+
+    values = _mapping_first(data, ("frequencies", "freq"))
+    if values is None:
+        raise ValueError("harmonic data must include vibrational frequencies")
+    frequencies = _signed_frequency_array(values, name="frequencies")
+    unit = str(data.get("frequency_unit", "cm^-1")).strip().lower()
+    if unit in {"cm^-1", "cm-1", "wavenumber", "wavenumbers", "1/cm"}:
+        return frequencies
+    if unit in {"au", "a.u.", "hartree", "eh"}:
+        converted = frequencies * au2wavenumber
+        if np.max(np.abs(converted), initial=0.0) > _MAX_FLOAT32:
+            raise ValueError("converted frequencies must fit in float32")
+        return converted
+    raise ValueError("normal-mode frequency_unit must be 'cm^-1' or 'au'")
+
+
+def _optional_mode_values(data, names, nmodes, *, name, positive=False):
+    values = _mapping_first(data, names)
+    if values is None:
+        return None
+    array = _real_array(values, name=name)
+    if array.shape != (nmodes,):
+        raise ValueError(f"{name} must have one value per normal mode")
+    if positive:
+        if np.any(array <= 0.0):
+            raise ValueError(f"{name} values must be positive")
+    elif np.any(array < 0.0):
+        raise ValueError(f"{name} values must be non-negative")
+    if np.max(np.abs(array), initial=0.0) > _MAX_FLOAT32:
+        raise ValueError(f"{name} values must fit in float32")
+    return array
+
+
+def _normal_mode_indices(selector, nmodes: int) -> list[int]:
+    if selector is True or (isinstance(selector, str) and selector.strip().lower() == "all"):
+        indices = list(range(nmodes))
+    elif isinstance(selector, str):
+        raise ValueError("normal_modes must be an integer index, a list, or 'all'")
+    elif isinstance(selector, (bool, np.bool_)):
+        raise TypeError("normal-mode indices cannot be boolean")
+    elif isinstance(selector, Integral):
+        indices = [int(selector)]
+    else:
+        try:
+            requested = list(selector)
+        except TypeError as exc:
+            raise TypeError(
+                "normal_modes must be an integer index, a list, or 'all'"
+            ) from exc
+        if not requested:
+            raise ValueError("normal_modes selector cannot be empty")
+        if any(
+            isinstance(item, (bool, np.bool_)) or not isinstance(item, Integral)
+            for item in requested
+        ):
+            raise TypeError("normal-mode indices must be integers")
+        indices = [int(item) for item in requested]
+
+    if not indices:
+        raise ValueError("harmonic data contains no normal modes")
+    if len(indices) > _MAX_NORMAL_MODES:
+        raise ValueError(f"select at most {_MAX_NORMAL_MODES} normal modes")
+    if len(indices) != len(set(indices)):
+        raise ValueError("normal-mode selector contains duplicate indices")
+    if any(index < 0 or index >= nmodes for index in indices):
+        raise IndexError(f"normal-mode index is outside [0, {nmodes})")
+    return indices
+
+
+def _normal_mode_objects(obj, selector) -> tuple[NormalMode, ...]:
+    data = _normal_mode_source_mapping(obj)
+    frequencies = _frequencies_cm1(data)
+    raw_modes = _mapping_first(data, ("modes", "norm_mode", "normal_modes"))
+    if raw_modes is None:
+        raise ValueError("harmonic data must include modes or norm_mode")
+    modes = _real_array(raw_modes, name="normal modes")
+    if modes.ndim != 3 or modes.shape[-1] != 3:
+        raise ValueError("normal modes must have shape (nmodes, natom, 3)")
+    if modes.shape[0] != frequencies.size:
+        raise ValueError("frequencies and normal modes must have the same length")
+    if not 1 <= modes.shape[1] <= _MAX_ATOMS:
+        raise ValueError(f"normal modes must contain between 1 and {_MAX_ATOMS} atoms")
+
+    nmodes = frequencies.size
+    reduced_masses = _optional_mode_values(
+        data,
+        ("reduced_mass_amu", "reduced_masses", "reduced_mass"),
+        nmodes,
+        name="reduced masses",
+        positive=True,
+    )
+    intensities = _optional_mode_values(
+        data,
+        ("intensities", "intensity"),
+        nmodes,
+        name="intensities",
+    )
+    intensity_unit = data.get("intensity_unit") if intensities is not None else None
+
+    result = []
+    for index in _normal_mode_indices(selector, nmodes):
+        frequency = float(frequencies[index])
+        result.append(
+            NormalMode(
+                name=f"mode-{index + 1}",
+                label=f"Mode {index + 1}",
+                displacements=modes[index],
+                frequency_cm1=frequency,
+                reduced_mass_amu=(
+                    None if reduced_masses is None else reduced_masses[index]
+                ),
+                intensity=None if intensities is None else intensities[index],
+                intensity_unit=intensity_unit,
+                source_index=index,
+            )
+        )
+    return tuple(result)
+
+
+def _normal_mode_geometry_arrays(obj):
+    if isinstance(obj, Mapping):
+        coords = _mapping_first(obj, ("coords", "atom_coords", "coordinates"))
+        symbols = _mapping_first(obj, ("atom_symbols", "symbols"))
+    else:
+        coords = getattr(obj, "coords", None)
+        symbols = getattr(obj, "atom_symbols", None)
+        if callable(symbols):
+            symbols = symbols()
+        if coords is None:
+            coords = getattr(obj, "_coords", None)
+        if symbols is None:
+            symbols = getattr(obj, "_atom_symbols", None)
+    if coords is None or symbols is None:
+        return None
+    return symbols, coords
+
+
+def _normal_mode_xyz(obj, molecule, *, coordinates_unit: str) -> str:
+    candidates = []
+    if molecule is not None:
+        candidates.append(molecule)
+    else:
+        candidates.append(obj)
+        if isinstance(obj, Mapping):
+            embedded = _mapping_first(obj, ("molecule", "mol"))
+            if embedded is not None:
+                candidates.append(embedded)
+        backend = getattr(obj, "backend", None)
+        if backend is not None:
+            candidates.append(backend)
+
+    for candidate in candidates:
+        try:
+            source = _molecule_from_object(candidate)
+        except TypeError:
+            continue
+        if (
+            molecule is None
+            and candidate is obj
+            and getattr(obj, "hess", None) is not None
+        ):
+            stored_coords = getattr(obj, "coords", getattr(obj, "_coords", None))
+            if stored_coords is not None:
+                stored_coords = np.asarray(stored_coords, dtype=float)
+                current_coords = np.asarray(source.atom_coords(), dtype=float)
+                if (
+                    stored_coords.shape == current_coords.shape
+                    and not np.allclose(
+                        stored_coords,
+                        current_coords,
+                        rtol=1.0e-10,
+                        atol=1.0e-12,
+                    )
+                ):
+                    raise ValueError(
+                        "the Hessian molecule geometry changed after the Hessian was built; "
+                        "rebuild the Hessian or pass molecule= explicitly"
+                    )
+        return _molecule_xyz(source, coordinates_unit=coordinates_unit)
+
+    array_sources = [obj]
+    backend = getattr(obj, "backend", None)
+    if backend is not None:
+        array_sources.append(backend)
+    for source in array_sources:
+        arrays = _normal_mode_geometry_arrays(source)
+        if arrays is not None:
+            symbols, coords = arrays
+            return _xyz_from_arrays(
+                symbols,
+                coords,
+                coordinates_unit=coordinates_unit,
+            )
+
+    raise TypeError(
+        "normal-mode geometry is missing; pass molecule=mol for harmonic-analysis data"
+    )
+
+
 _ELEMENT_SYMBOLS = (
     "X", "H", "He", "Li", "Be", "B", "C", "N", "O", "F", "Ne", "Na",
     "Mg", "Al", "Si", "P", "S", "Cl", "Ar", "K", "Ca", "Sc", "Ti", "V",
@@ -1824,10 +2204,6 @@ def _read_cube(path: Path, *, dataset: int | str = 0):
 def view(
     obj,
     *,
-    mode: int | None = None,
-    amplitude: str | float = "auto",
-    frames: int = 24,
-    interval: int = 30,
     orbital=None,
     coeff=None,
     orbital_spin: str = "auto",
@@ -1839,6 +2215,10 @@ def view(
     nto_method: str = "x",
     fields: ScalarField3D | Iterable[ScalarField3D] | None = None,
     active_field: str | int | None = None,
+    normal_modes=None,
+    active_mode: str | int | None = None,
+    mode_amplitude: float = 0.25,
+    molecule=None,
     dataset: int | str = 0,
     nx: int = 40,
     ny: int | None = None,
@@ -1859,42 +2239,43 @@ def view(
 
     Examples
     --------
-    ``view(mol)`` shows geometry and ``view(hessian, mode=0)`` animates one
-    harmonic normal mode.  For a converged SCF object, use
+    ``view(mol)`` shows geometry.  For a converged SCF object, use
     ``view(mf, orbital=['homo', 'lumo'])``, ``orbital='all'``,
     ``density='all'`` (including unrestricted spin density), or ``esp=True``.
     ``view(td, nto='all')`` builds NTO hole/particle layers for every exposed
-    excited-state amplitude.  A Gaussian cube path is accepted directly.
+    excited-state amplitude.  ``view(hess, normal_modes='all')`` animates a
+    completed Hessian's normal modes.  For a standalone harmonic-analysis
+    mapping, supply its geometry with ``molecule=mol``.  A Gaussian cube path
+    is accepted directly.
 
     Coordinates in generated grids are sampled in Bohr and transported to the
-    browser in Angstrom.  Scalar values retain their documented atomic units.
-    Volumetric data is never encoded in a URL fragment.
+    browser in Angstrom.  ``mode_amplitude`` is the largest displayed atomic
+    displacement in Angstrom.  Scalar values retain their documented atomic
+    units.  Volumetric and normal-mode data is never encoded in a URL fragment.
     """
     esp_requested = esp is not None and esp is not False
     density_requested = density is not None and density is not False
     nto_requested = nto is not None and nto is not False
-    mode_requested = mode is not None
-    if mode_requested and (
-        orbital is not None
-        or coeff is not None
-        or density_requested
-        or nto_requested
-        or fields is not None
-        or esp_requested
+    modes_requested = normal_modes is not None and normal_modes is not False
+    if not modes_requested and (
+        active_mode is not None
+        or molecule is not None
+        or mode_amplitude != 0.25
     ):
-        raise ValueError("normal-mode animation cannot be combined with scalar fields")
+        raise ValueError(
+            "active_mode, mode_amplitude, and molecule require normal_modes"
+        )
     if isinstance(obj, SceneView):
         if (
-            mode_requested
-            or amplitude != "auto"
-            or orbital is not None
+            orbital is not None
             or coeff is not None
             or density_requested
             or nto_requested
             or fields is not None
             or esp_requested
+            or modes_requested
         ):
-            raise ValueError("cannot add computed fields when obj is already a SceneView")
+            raise ValueError("cannot add computed data when obj is already a SceneView")
         result = obj
     elif isinstance(obj, (str, Path)):
         path = Path(obj).expanduser()
@@ -1903,16 +2284,15 @@ def view(
         if path.suffix.lower() not in {".cube", ".cub"}:
             raise ValueError("view(path) currently accepts .cube and .cub files")
         if (
-            mode_requested
-            or amplitude != "auto"
-            or orbital is not None
+            orbital is not None
             or coeff is not None
             or density_requested
             or nto_requested
             or fields is not None
             or esp_requested
+            or modes_requested
         ):
-            raise ValueError("computed field options cannot be combined with a cube path")
+            raise ValueError("computed data options cannot be combined with a cube path")
         xyz, cube_fields = _read_cube(path, dataset=dataset)
         result = VolumeView(
             xyz=xyz,
@@ -1924,20 +2304,40 @@ def view(
             title=title or cube_fields[0].label,
             active_field=active_field,
         )
-    else:
-        molecule = _molecule_from_object(obj)
-        xyz = _molecule_xyz(molecule, coordinates_unit=coordinates_unit)
-        vibration = None
-        if mode_requested:
-            vibration = _normal_mode_animation(
-                obj,
-                molecule,
-                mode=mode,
-                amplitude=amplitude,
-                coordinates_unit=coordinates_unit,
-                frames=frames,
-                interval=interval,
+    elif modes_requested:
+        if (
+            orbital is not None
+            or coeff is not None
+            or density_requested
+            or nto_requested
+            or fields is not None
+            or esp_requested
+            or active_field is not None
+        ):
+            raise ValueError(
+                "normal modes cannot be combined with scalar fields, orbitals, "
+                "densities, ESP, or NTOs"
             )
+        mode_objects = _normal_mode_objects(obj, normal_modes)
+        xyz = _normal_mode_xyz(
+            obj,
+            molecule,
+            coordinates_unit=coordinates_unit,
+        )
+        result = SceneView(
+            xyz=xyz,
+            normal_modes=mode_objects,
+            representation=representation,
+            labels=bool(labels),
+            width=width,
+            height=height,
+            title=title,
+            active_mode=active_mode,
+            mode_amplitude=mode_amplitude,
+        )
+    else:
+        molecular_geometry = _molecule_from_object(obj)
+        xyz = _molecule_xyz(molecular_geometry, coordinates_unit=coordinates_unit)
         external_fields: list[ScalarField3D] = []
         if fields is not None:
             if isinstance(fields, ScalarField3D):
@@ -1958,7 +2358,7 @@ def view(
             if reference is None:
                 raise TypeError("orbital, density, ESP, and NTO views require an SCF reference")
             cube = _grid(
-                molecule,
+                molecular_geometry,
                 nx=nx,
                 ny=ny,
                 nz=nz,
@@ -2038,9 +2438,8 @@ def view(
             labels=bool(labels),
             width=width,
             height=height,
-            title=title or (vibration.label if vibration is not None else None),
+            title=title,
             active_field=active_field,
-            vibration=vibration,
         )
 
     should_open = not _in_notebook() if open_browser is None else bool(open_browser)
@@ -2049,4 +2448,11 @@ def view(
     return result
 
 
-__all__ = ["MoleculeView", "ScalarField3D", "SceneView", "VolumeView", "view"]
+__all__ = [
+    "MoleculeView",
+    "NormalMode",
+    "ScalarField3D",
+    "SceneView",
+    "VolumeView",
+    "view",
+]

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -6,9 +6,10 @@ import pytest
 
 import pyqed
 from pyqed.qchem import Molecule
-from pyqed.units import au2angstrom
+from pyqed.units import au2angstrom, au2wavenumber
 from pyqed.visualization import (
     MoleculeView,
+    NormalMode,
     ScalarField3D,
     SceneView,
     VolumeView,
@@ -22,17 +23,6 @@ class TinyMolecule:
 
     def atom_coords(self):
         return np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]])
-
-
-class TinyHessian:
-    mol = TinyMolecule()
-
-    def vibrational_analysis(self):
-        return {
-            "freq_cm1": np.array([1234.5]),
-            "modes": np.array([[[0.0, 0.0, -2.0], [0.0, 0.0, 1.0]]]),
-            "reduced_mass_amu": np.array([1.2]),
-        }
 
 
 def fragment_parameters(result):
@@ -77,50 +67,6 @@ def test_view_provides_an_inline_notebook_representation():
     assert "allow-scripts" in html
 
 
-def test_view_hessian_builds_browser_normal_mode_animation():
-    default_result = view(TinyHessian(), mode=0, open_browser=False)
-    assert default_result.payload()["vibration"]["interval"] == 30
-
-    result = view(
-        TinyHessian(),
-        mode=0,
-        amplitude=0.25,
-        frames=32,
-        interval=45,
-        open_browser=False,
-    )
-
-    payload = result.payload()
-    vibration = payload["vibration"]
-    assert result.url == "https://pyqed.org/viewer"
-    assert result.title == "Mode 0: 1234.5 cm^-1"
-    assert vibration["mode_index"] == 0
-    assert vibration["frequency_cm1"] == pytest.approx(1234.5)
-    assert vibration["frames"] == 32
-    assert vibration["interval"] == 45
-    assert vibration["amplitude_angstrom"] == pytest.approx(0.25)
-    displacement = np.asarray(vibration["displacements"])
-    assert displacement.shape == (2, 3)
-    assert np.max(np.linalg.norm(displacement, axis=1)) == pytest.approx(0.25)
-    assert "postMessage" in result._repr_html_()
-
-
-def test_view_hessian_rejects_invalid_or_unavailable_modes():
-    with pytest.raises(IndexError, match="outside"):
-        view(TinyHessian(), mode=1, open_browser=False)
-    with pytest.raises(TypeError, match="integer"):
-        view(TinyHessian(), mode=True, open_browser=False)
-    with pytest.raises(TypeError, match="completed Hessian"):
-        view(TinyMolecule(), mode=0, open_browser=False)
-
-    class PendingHessian(TinyHessian):
-        def vibrational_analysis(self):
-            raise ValueError("run first")
-
-    with pytest.raises(ValueError, match="run the Hessian"):
-        view(PendingHessian(), mode=0, open_browser=False)
-
-
 def test_top_level_and_molecule_convenience_apis():
     mol = Molecule(atom="H 0 0 0; H 0 0 0.74", unit="angstrom")
 
@@ -129,6 +75,7 @@ def test_top_level_and_molecule_convenience_apis():
 
     assert fragment_parameters(direct)["xyz"] == fragment_parameters(method)["xyz"]
     assert "0.7400000000" in fragment_parameters(method)["xyz"][0]
+    assert pyqed.NormalMode is NormalMode
     assert pyqed.ScalarField3D is ScalarField3D
     assert pyqed.SceneView is SceneView
     assert pyqed.VolumeView is VolumeView
@@ -441,3 +388,313 @@ def test_cube_uses_both_header_lines_and_can_load_all_datasets(tmp_path):
     assert all(field.kind == "orbital" for field in scene.fields)
     np.testing.assert_array_equal(scene.fields[0].values.ravel(), np.arange(8.0))
     np.testing.assert_array_equal(scene.fields[1].values.ravel(), np.arange(10.0, 18.0))
+
+
+def test_normal_mode_owns_normalized_float32_data_and_serializes_base64():
+    vectors = np.array([[2.0, 0.0, 0.0], [0.0, -1.0, 0.0]])
+    mode = NormalMode(
+        "mode-1",
+        vectors,
+        -321.5,
+        label="Mode 1",
+        reduced_mass_amu=1.5,
+        intensity=8.0,
+        intensity_unit="km/mol",
+        source_index=0,
+    )
+    vectors[:] = 0.0
+    payload = mode.to_payload()
+    decoded = np.frombuffer(
+        base64.b64decode(payload["displacements"]),
+        dtype="<f4",
+    ).reshape(payload["shape"])
+
+    assert mode.displacements.dtype == np.float32
+    assert not mode.displacements.flags.writeable
+    np.testing.assert_allclose(decoded, [[1.0, 0.0, 0.0], [0.0, -0.5, 0.0]])
+    assert payload["frequency_cm1"] == -321.5
+    assert payload["displacement_encoding"] == "float32-le-base64"
+    assert payload["normalization"] == "max-atom-displacement"
+    assert payload["reduced_mass_amu"] == 1.5
+    assert payload["intensity_unit"] == "km/mol"
+
+    with pytest.raises(ValueError, match="cannot all be zero"):
+        NormalMode("zero", np.zeros((2, 3)), 1.0)
+    with pytest.raises(ValueError, match="shape"):
+        NormalMode("bad", np.ones((2, 2)), 1.0)
+    with pytest.raises(ValueError, match="positive"):
+        NormalMode("bad", np.ones((2, 3)), 1.0, reduced_mass_amu=0.0)
+    with pytest.raises(ValueError, match="non-negative"):
+        NormalMode("bad", np.ones((2, 3)), 1.0, intensity=-1.0)
+    with pytest.raises(ValueError, match="JavaScript-safe"):
+        NormalMode(
+            "bad",
+            np.ones((2, 3)),
+            1.0,
+            source_index=1 << 53,
+        )
+
+
+def test_view_extracts_all_hessian_modes_with_signed_frequencies_and_metadata():
+    class TinyHessian:
+        mol = TinyMolecule()
+
+        def __init__(self):
+            self.calls = 0
+
+        def vibrational_analysis(self):
+            self.calls += 1
+            return {
+                "freq_cm1": np.array([1200.0, -250.0]),
+                "modes": np.array(
+                    [
+                        [[2.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+                        [[0.0, 0.0, 1.0], [0.0, 0.0, -1.0]],
+                    ]
+                ),
+                "reduced_mass_amu": np.array([1.2, 2.4]),
+            }
+
+    hessian = TinyHessian()
+    scene = view(
+        hessian,
+        normal_modes="all",
+        active_mode=1,
+        mode_amplitude=0.3,
+        open_browser=False,
+    )
+    payload = scene.payload()
+
+    assert hessian.calls == 1
+    assert [mode.name for mode in scene.normal_modes] == ["mode-1", "mode-2"]
+    assert scene.active_mode == "mode-2"
+    assert scene.url == "https://pyqed.org/viewer"
+    assert urlsplit(scene.url).fragment == ""
+    assert "postMessage" in scene._repr_html_()
+    assert f"{2.0 * au2angstrom:.10f}" in scene.xyz
+    assert payload["normal_modes"]["active_mode"] == "mode-2"
+    assert payload["normal_modes"]["amplitude_angstrom"] == 0.3
+    assert payload["normal_modes"]["modes"][1]["frequency_cm1"] == -250.0
+    assert payload["normal_modes"]["modes"][1]["source_index"] == 1
+    assert payload["normal_modes"]["modes"][1]["label"] == "Mode 2"
+
+
+def test_view_accepts_completed_ir_style_objects_and_mode_subsets():
+    class CompletedIR:
+        frequencies = np.array([500.0, 1600.0])
+        modes = np.array(
+            [
+                [[1.0, 0.0, 0.0], [-1.0, 0.0, 0.0]],
+                [[0.0, 2.0, 0.0], [0.0, -1.0, 0.0]],
+            ]
+        )
+        reduced_masses = np.array([1.0, 3.0])
+        intensities = np.array([2.0, 7.0])
+        frequency_unit = "cm^-1"
+        intensity_unit = "km/mol"
+        coords = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]])
+        atom_symbols = ("H", "F")
+
+    scene = view(CompletedIR(), normal_modes=[1], open_browser=False)
+    mode = scene.normal_modes[0]
+
+    assert mode.name == "mode-2"
+    assert mode.frequency_cm1 == 1600.0
+    assert mode.reduced_mass_amu == 3.0
+    assert mode.intensity == 7.0
+    assert mode.intensity_unit == "km/mol"
+    np.testing.assert_allclose(
+        mode.displacements,
+        [[0.0, 1.0, 0.0], [0.0, -0.5, 0.0]],
+    )
+
+
+def test_view_does_not_call_generic_normal_modes_methods():
+    class UnpreparedDriver:
+        mol = TinyMolecule()
+
+        def __init__(self):
+            self.calls = 0
+
+        def normal_modes(self):
+            self.calls += 1
+            raise AssertionError("normal_modes() must not be called implicitly")
+
+    driver = UnpreparedDriver()
+    with pytest.raises(TypeError, match="completed harmonic data"):
+        view(driver, normal_modes="all", open_browser=False)
+    assert driver.calls == 0
+
+
+def test_view_rejects_a_hessian_whose_live_geometry_has_changed():
+    class ChangedMolecule(TinyMolecule):
+        def atom_coords(self):
+            return np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 9.0]])
+
+    class StaleHessian:
+        mol = ChangedMolecule()
+        coords = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]])
+        hess = np.eye(6)
+
+        def vibrational_analysis(self):
+            return {
+                "freq_cm1": [1000.0],
+                "modes": [[[1.0, 0.0, 0.0], [-1.0, 0.0, 0.0]]],
+            }
+
+    with pytest.raises(ValueError, match="geometry changed"):
+        view(StaleHessian(), normal_modes="all", open_browser=False)
+
+
+def test_view_accepts_unrun_ir_built_from_harmonic_analysis():
+    from pyqed.qchem import IR
+
+    ir = IR.from_harmonic_analysis(
+        {
+            "freq_cm1": [750.0],
+            "modes": [[[1.0, 0.0, 0.0], [-1.0, 0.0, 0.0]]],
+            "reduced_mass_amu": [1.7],
+            "coords": [[0.0, 0.0, 0.0], [0.0, 0.0, 2.0]],
+            "atom_symbols": ["H", "F"],
+        },
+        intensities=[4.5],
+    )
+
+    scene = view(ir, normal_modes="all", open_browser=False)
+
+    assert scene.normal_modes[0].frequency_cm1 == 750.0
+    assert scene.normal_modes[0].reduced_mass_amu == 1.7
+    assert scene.normal_modes[0].intensity == 4.5
+    assert scene.normal_modes[0].intensity_unit == "au"
+
+
+def test_view_accepts_harmonic_mapping_with_explicit_molecule_and_au_frequencies():
+    data = {
+        "freq_au": np.array([0.01j, 0.02]),
+        "norm_mode": np.array(
+            [
+                [[1.0, 0.0, 0.0], [-1.0, 0.0, 0.0]],
+                [[0.0, 1.0, 0.0], [0.0, -1.0, 0.0]],
+            ]
+        ),
+        "reduced_mass": np.array([1.0, 2.0]),
+    }
+    scene = view(
+        data,
+        molecule=TinyMolecule(),
+        normal_modes="all",
+        open_browser=False,
+    )
+
+    assert scene.normal_modes[0].frequency_cm1 == pytest.approx(-0.01 * au2wavenumber)
+    assert scene.normal_modes[1].frequency_cm1 == pytest.approx(0.02 * au2wavenumber)
+
+    with pytest.raises(TypeError, match="pass molecule"):
+        view(data, normal_modes="all", open_browser=False)
+
+
+@pytest.mark.parametrize(
+    ("selector", "error", "message"),
+    [
+        (False, ValueError, "require normal_modes"),
+        ([], ValueError, "cannot be empty"),
+        ([0, 0], ValueError, "duplicate"),
+        ([2], IndexError, "outside"),
+        ([True], TypeError, "integers"),
+        ([0.0], TypeError, "integers"),
+    ],
+)
+def test_normal_mode_selectors_are_strict(selector, error, message):
+    data = {
+        "freq_cm1": [100.0, 200.0],
+        "modes": np.ones((2, 2, 3)),
+    }
+    kwargs = {"active_mode": 0} if selector is False else {}
+    with pytest.raises(error, match=message):
+        view(
+            data,
+            molecule=TinyMolecule() if selector is not False else None,
+            normal_modes=selector,
+            open_browser=False,
+            **kwargs,
+        )
+
+
+def test_normal_mode_views_reject_inconsistent_or_misleading_scenes():
+    data = {
+        "freq_cm1": [100.0],
+        "modes": np.ones((1, 2, 3)),
+    }
+    field = ScalarField3D("field", np.ones((2, 2, 2)), (0, 0, 0), np.eye(3))
+
+    with pytest.raises(ValueError, match="cannot be combined"):
+        view(
+            data,
+            molecule=TinyMolecule(),
+            normal_modes="all",
+            fields=field,
+            open_browser=False,
+        )
+    with pytest.raises(ValueError, match="same length"):
+        view(
+            {"freq_cm1": [1.0, 2.0], "modes": np.ones((1, 2, 3))},
+            molecule=TinyMolecule(),
+            normal_modes="all",
+            open_browser=False,
+        )
+    with pytest.raises(ValueError, match="purely imaginary"):
+        view(
+            {"freq_cm1": [1.0 + 2.0j], "modes": np.ones((1, 2, 3))},
+            molecule=TinyMolecule(),
+            normal_modes="all",
+            open_browser=False,
+        )
+    with pytest.raises(ValueError, match="one displacement vector per atom"):
+        SceneView(
+            xyz="H 0 0 0",
+            normal_modes=(NormalMode("mode-1", np.ones((2, 3)), 100.0),),
+        )
+    with pytest.raises(ValueError, match="mode_amplitude"):
+        view(
+            data,
+            molecule=TinyMolecule(),
+            normal_modes="all",
+            mode_amplitude=0.0,
+            open_browser=False,
+        )
+    with pytest.raises(ValueError, match="mode_amplitude"):
+        view(
+            data,
+            molecule=TinyMolecule(),
+            normal_modes="all",
+            mode_amplitude=0.009,
+            open_browser=False,
+        )
+    with pytest.raises(ValueError, match="at most 512"):
+        view(
+            {
+                "freq_cm1": np.arange(513.0),
+                "modes": np.ones((513, 2, 3)),
+            },
+            molecule=TinyMolecule(),
+            normal_modes="all",
+            open_browser=False,
+        )
+
+
+def test_normal_mode_scene_opens_a_launcher_not_a_fragment(monkeypatch):
+    opened = []
+    monkeypatch.setattr("webbrowser.open_new_tab", lambda url: opened.append(url) or True)
+    scene = view(
+        {
+            "freq_cm1": [100.0],
+            "modes": np.ones((1, 2, 3)),
+        },
+        molecule=TinyMolecule(),
+        normal_modes="all",
+        open_browser=True,
+    )
+
+    assert scene.url == "https://pyqed.org/viewer"
+    assert len(opened) == 1
+    assert opened[0].startswith("file:")

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -325,7 +325,8 @@ summary:focus-visible {
 }
 
 .preset-row button,
-.viewer-controls button {
+.viewer-controls button,
+.normal-mode-panel button {
   min-height: 36px;
   border: 1px solid rgba(168, 238, 242, 0.23);
   background: rgba(255, 255, 255, 0.025);
@@ -342,12 +343,15 @@ summary:focus-visible {
 
 .preset-row button:hover,
 .viewer-controls button:hover,
-.viewer-controls button.is-active {
+.viewer-controls button.is-active,
+.normal-mode-panel button:hover:not(:disabled),
+.normal-mode-panel button.is-active {
   border-color: var(--cyan);
   color: var(--cyan-soft);
 }
 
-.viewer-controls button.is-active {
+.viewer-controls button.is-active,
+.normal-mode-panel button.is-active {
   background: rgba(53, 214, 227, 0.1);
 }
 
@@ -380,7 +384,10 @@ summary:focus-visible {
 .viewer-input-panel textarea:focus,
 .viewer-input-panel select:focus,
 .viewer-controls select:focus,
-.viewer-controls input:focus {
+.viewer-controls input:focus,
+.normal-mode-panel select:focus,
+.normal-mode-panel input:focus-visible,
+.normal-mode-panel button:focus-visible {
   border-color: var(--cyan);
   box-shadow: 0 0 0 2px rgba(53, 214, 227, 0.1);
 }
@@ -518,6 +525,10 @@ summary:focus-visible {
   background: #071720;
 }
 
+.viewer-display-panel.has-normal-modes {
+  grid-template-rows: auto auto minmax(480px, 1fr) auto;
+}
+
 .viewer-toolbar {
   display: flex;
   min-height: 90px;
@@ -594,9 +605,119 @@ summary:focus-visible {
 }
 
 .viewer-controls select:disabled,
-.viewer-controls input:disabled {
+.viewer-controls input:disabled,
+.viewer-controls button:disabled {
   cursor: not-allowed;
   opacity: 0.48;
+}
+
+.normal-mode-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) repeat(3, minmax(0, 1fr));
+  align-items: end;
+  gap: 0.7rem;
+  padding: 0.85rem 1.25rem;
+  border-bottom: 1px solid var(--rule-dark);
+  background: #081923;
+}
+
+.normal-mode-select {
+  grid-column: span 2;
+}
+
+.normal-mode-panel label,
+.normal-mode-frequency {
+  display: grid;
+  gap: 0.3rem;
+  color: #aec0c5;
+  font-size: 0.64rem;
+  font-weight: 760;
+  letter-spacing: 0.065em;
+  text-transform: uppercase;
+}
+
+.normal-mode-panel select {
+  width: 100%;
+  min-height: 36px;
+  padding: 0 0.55rem;
+  border: 1px solid rgba(168, 238, 242, 0.24);
+  border-radius: 0;
+  outline: none;
+  background: #071720;
+  color: #d8e6e8;
+  font-family: var(--mono);
+  font-size: 0.69rem;
+  text-transform: none;
+}
+
+.normal-mode-frequency {
+  position: relative;
+  align-self: stretch;
+  justify-content: center;
+  padding: 0.2rem 0.75rem;
+  border-left: 2px solid #f3c969;
+  background: rgba(243, 201, 105, 0.055);
+}
+
+.normal-mode-frequency strong {
+  color: #f4dc9d;
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.normal-mode-frequency em {
+  color: #ffb0ac;
+  font-size: 0.58rem;
+  font-style: normal;
+}
+
+.normal-mode-panel button {
+  min-height: 36px;
+  padding: 0.4rem 0.65rem;
+}
+
+.normal-mode-panel button:disabled {
+  cursor: not-allowed;
+  opacity: 0.42;
+}
+
+.normal-mode-play {
+  min-width: 68px;
+}
+
+.normal-mode-slider > span {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.55rem;
+}
+
+.normal-mode-slider output {
+  color: #f4dc9d;
+  font-family: var(--mono);
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.normal-mode-slider input {
+  width: 100%;
+  min-height: 18px;
+  accent-color: #f3c969;
+  cursor: pointer;
+}
+
+.normal-mode-slider input:disabled {
+  cursor: not-allowed;
+  opacity: 0.42;
+}
+
+.normal-mode-details {
+  grid-column: 1 / -1;
+  margin: 0;
+  color: #768f98;
+  font-size: 0.62rem;
+  line-height: 1.45;
 }
 
 .molecule-canvas-wrap {
@@ -733,6 +854,14 @@ summary:focus-visible {
 .element-legend i.surface-negative {
   border-radius: 2px;
   background: #f38b6b;
+}
+
+.element-legend i.normal-mode-vector {
+  width: 22px;
+  height: 3px;
+  border: 0;
+  border-radius: 1px;
+  background: #f3c969;
 }
 
 .element-legend .esp-gradient-key i {
@@ -2283,6 +2412,10 @@ footer {
     justify-content: flex-start;
   }
 
+  .normal-mode-details {
+    grid-column: 1 / -1;
+  }
+
   .hero-content {
     min-height: 650px;
     grid-template-columns: minmax(0, 1fr) minmax(300px, 0.6fr);
@@ -2373,6 +2506,26 @@ footer {
 
   .viewer-display-panel {
     grid-template-rows: auto 430px auto;
+  }
+
+  .viewer-display-panel.has-normal-modes {
+    grid-template-rows: auto auto 430px auto;
+  }
+
+  .normal-mode-panel {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    align-items: stretch;
+    padding: 0.85rem 1rem;
+  }
+
+  .normal-mode-select,
+  .normal-mode-details {
+    grid-column: 1 / -1;
+  }
+
+  .normal-mode-panel button,
+  .normal-mode-frequency {
+    align-self: stretch;
   }
 
   .molecule-canvas,

--- a/website/app/viewer/molecule-viewer.tsx
+++ b/website/app/viewer/molecule-viewer.tsx
@@ -14,15 +14,18 @@ import {
 } from "react";
 import type {
   Atom,
+  NormalMode,
   ValidatedScene,
   VolumeField,
 } from "./volume-data.mjs";
 import {
   MAX_CUBE_FILE_BYTES,
+  displacedAtoms,
   fieldToCube,
   gridsMatch,
   parseCube,
   parseGeometry,
+  symmetricNormalModeFrame,
   validateSceneMessage,
   xyzFor,
 } from "./volume-data.mjs";
@@ -30,10 +33,9 @@ import {
 type Bond = [number, number];
 type RenderMode = "ball-stick" | "space-fill" | "wireframe";
 type SurfaceMode = "both" | "positive" | "negative" | "esp-map" | "hidden";
-type Vibration = NonNullable<ValidatedScene["vibration"]>;
 
 type ViewerApi = {
-  animate(options: Record<string, unknown>): unknown;
+  addArrow(options: Record<string, unknown>): unknown;
   addIsosurface(data: unknown, options: Record<string, unknown>): unknown;
   addLabel(text: string, options: Record<string, unknown>): unknown;
   addModel(data: string, format: string): unknown;
@@ -49,16 +51,11 @@ type ViewerApi = {
   removeAllSurfaces(): unknown;
   render(callback?: () => void): unknown;
   resize(): unknown;
+  setFrame(frame: number): Promise<unknown>;
   setStyle(selection: Record<string, never>, style: Record<string, unknown>): unknown;
   setView(view: number[]): unknown;
   spin(axis: string | false, speed?: number): unknown;
-  stopAnimate(): unknown;
-  vibrate(
-    frames: number,
-    amplitude: number,
-    bothWays: boolean,
-    arrowSpec?: Record<string, unknown>,
-  ): unknown;
+  vibrate(frames: number, amplitude: number, bothWays: boolean): unknown;
   zoomTo(): unknown;
 };
 
@@ -135,6 +132,33 @@ const FIELD_KIND_LABELS: Record<VolumeField["kind"], string> = {
   esp: "Electrostatic potential",
   generic: "Scalar field",
 };
+
+const NORMAL_MODE_FRAME_STEPS = 30;
+const NORMAL_MODE_BASE_CYCLES_PER_SECOND = 0.75;
+
+function frequencyLabel(frequencyCm1: number): string {
+  const magnitude = Math.abs(frequencyCm1).toLocaleString("en-US", {
+    maximumFractionDigits: 1,
+    minimumFractionDigits: 1,
+  });
+  return frequencyCm1 < 0 ? `${magnitude} i cm⁻¹` : `${magnitude} cm⁻¹`;
+}
+
+function xyzWithMode(atoms: Atom[], normalMode: NormalMode): string {
+  const rows = atoms.map((atom, index) => {
+    const offset = index * 3;
+    return [
+      atom.element,
+      atom.x.toPrecision(12),
+      atom.y.toPrecision(12),
+      atom.z.toPrecision(12),
+      normalMode.displacements[offset].toPrecision(9),
+      normalMode.displacements[offset + 1].toPrecision(9),
+      normalMode.displacements[offset + 2].toPrecision(9),
+    ].join(" ");
+  });
+  return `${atoms.length}\n${normalMode.label} · normalized displacement vectors\n${rows.join("\n")}\n`;
+}
 
 function inferBonds(atoms: Atom[]): Bond[] {
   const bonds: Bond[] = [];
@@ -213,44 +237,49 @@ function modelStyle(mode: RenderMode): Record<string, unknown> {
   };
 }
 
-function vibrationalXyz(atoms: Atom[], vibration: Vibration): string {
-  const rows = atoms.map((atom, index) => {
-    const [dx, dy, dz] = vibration.displacements[index];
-    return `${atom.element.padEnd(2)} ${atom.x.toFixed(10)} ${atom.y.toFixed(10)} ${atom.z.toFixed(10)} ${dx.toFixed(10)} ${dy.toFixed(10)} ${dz.toFixed(10)}`;
-  });
-  return `${atoms.length}\nMode ${vibration.modeIndex}: ${vibration.frequencyCm1.toFixed(3)} cm^-1\n${rows.join("\n")}\n`;
-}
-
 function MolecularFieldCanvas({
   atoms,
   fields,
   activeFieldIndex,
+  normalMode,
+  modeAmplitude,
+  modeSpeed,
+  modePlaying,
+  modePhaseRequest,
+  showModeArrows,
+  onModePhase,
   mode,
   labels,
   autoRotate,
   surfaceMode,
   isovalue,
   resetSignal,
-  vibration,
-  vibrationPlaying,
 }: {
   atoms: Atom[];
   fields: VolumeField[];
   activeFieldIndex: number;
+  normalMode: NormalMode | undefined;
+  modeAmplitude: number;
+  modeSpeed: number;
+  modePlaying: boolean;
+  modePhaseRequest: { phase: number; serial: number };
+  showModeArrows: boolean;
+  onModePhase: (phase: number) => void;
   mode: RenderMode;
   labels: boolean;
   autoRotate: boolean;
   surfaceMode: SurfaceMode;
   isovalue: number;
   resetSignal: number;
-  vibration: Vibration | null;
-  vibrationPlaying: boolean;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const viewerRef = useRef<ViewerApi | null>(null);
   const libraryRef = useRef<ThreeDmolApi | null>(null);
   const hasRendered = useRef(false);
   const renderRevision = useRef(0);
+  const modePhaseRef = useRef(0);
+  const modeNameRef = useRef<string | null>(null);
+  const renderedFrameRef = useRef(-1);
   const volumeCacheRef = useRef<WeakMap<VolumeField, unknown>>(new WeakMap());
   const [rendererStatus, setRendererStatus] = useState<"loading" | "ready" | "error">("loading");
 
@@ -281,7 +310,6 @@ function MolecularFieldCanvas({
     return () => {
       cancelled = true;
       renderRevision.current += 1;
-      viewerRef.current?.stopAnimate();
       viewerRef.current?.spin(false);
       viewerRef.current = null;
       libraryRef.current = null;
@@ -290,38 +318,49 @@ function MolecularFieldCanvas({
     };
   }, []);
 
+  const setNormalModeFrame = useCallback((viewer: ViewerApi, phase: number) => {
+    if (!normalMode) return;
+    const { frame, displacementScale } = symmetricNormalModeFrame(
+      phase,
+      NORMAL_MODE_FRAME_STEPS,
+    );
+    if (frame === renderedFrameRef.current) return;
+    renderedFrameRef.current = frame;
+    onModePhase(Math.asin(displacementScale));
+    void viewer.setFrame(frame).then(
+      () => {
+        if (viewerRef.current === viewer) viewer.render();
+      },
+      () => undefined,
+    );
+  }, [normalMode, onModePhase]);
+
   useEffect(() => {
     if (rendererStatus !== "ready") return;
     const viewer = viewerRef.current;
     if (!viewer) return;
     const previousView = hasRendered.current ? viewer.getView() : null;
 
-    viewer.stopAnimate();
+    if (modeNameRef.current !== (normalMode?.name ?? null)) {
+      modeNameRef.current = normalMode?.name ?? null;
+      modePhaseRef.current = 0;
+      onModePhase(0);
+    }
+    renderedFrameRef.current = -1;
     viewer.removeAllLabels();
     viewer.removeAllModels();
     if (atoms.length > 0) {
-      viewer.addModel(
-        vibration ? vibrationalXyz(atoms, vibration) : xyzFor(atoms),
-        "xyz",
-      );
+      viewer.addModel(normalMode ? xyzWithMode(atoms, normalMode) : xyzFor(atoms), "xyz");
       viewer.setStyle({}, modelStyle(mode));
-      if (vibration) {
-        viewer.vibrate(vibration.frames, 1, true, {
-          color: "#35d6e3",
-          radius: 0.045,
-          radiusRatio: 1.7,
-        });
-        if (vibrationPlaying) {
-          viewer.animate({
-            interval: vibration.interval,
-            loop: "backAndForth",
-            reps: 0,
-          });
-        }
+      if (normalMode) {
+        const scaledModeAmplitude =
+          modeAmplitude * NORMAL_MODE_FRAME_STEPS / (NORMAL_MODE_FRAME_STEPS - 1);
+        viewer.vibrate(NORMAL_MODE_FRAME_STEPS, scaledModeAmplitude, true);
+        setNormalModeFrame(viewer, modePhaseRef.current);
       }
     }
 
-    if (labels && atoms.length > 0 && !vibration) {
+    if (labels && atoms.length > 0 && !normalMode) {
       atoms.forEach((atom, index) => {
         viewer.addLabel(`${atom.element}${index + 1}`, {
           position: { x: atom.x, y: atom.y, z: atom.z },
@@ -340,7 +379,24 @@ function MolecularFieldCanvas({
     else if (previousView) viewer.setView(previousView);
     viewer.render();
     hasRendered.current = true;
-  }, [atoms, labels, mode, rendererStatus, vibration, vibrationPlaying]);
+  }, [
+    atoms,
+    labels,
+    mode,
+    modeAmplitude,
+    normalMode,
+    onModePhase,
+    rendererStatus,
+    setNormalModeFrame,
+  ]);
+
+  useEffect(() => {
+    if (rendererStatus !== "ready" || !normalMode) return;
+    const viewer = viewerRef.current;
+    if (!viewer) return;
+    modePhaseRef.current = modePhaseRequest.phase;
+    setNormalModeFrame(viewer, modePhaseRequest.phase);
+  }, [modePhaseRequest, normalMode, rendererStatus, setNormalModeFrame]);
 
   useEffect(() => {
     if (rendererStatus !== "ready") return;
@@ -431,14 +487,73 @@ function MolecularFieldCanvas({
       }
     }
 
+    if (normalMode && showModeArrows) {
+      atoms.forEach((atom, atomIndex) => {
+        const offset = atomIndex * 3;
+        const x = normalMode.displacements[offset];
+        const y = normalMode.displacements[offset + 1];
+        const z = normalMode.displacements[offset + 2];
+        if (Math.hypot(x, y, z) < 1e-7) return;
+        viewer.addArrow({
+          start: { x: atom.x, y: atom.y, z: atom.z },
+          end: {
+            x: atom.x + x * modeAmplitude,
+            y: atom.y + y * modeAmplitude,
+            z: atom.z + z * modeAmplitude,
+          },
+          color: "#f3c969",
+          radius: 0.045,
+          radiusRatio: 1.7,
+          mid: 0.74,
+        });
+      });
+    }
+
     viewer.render();
   }, [
     activeFieldIndex,
     atoms,
     fields,
     isovalue,
+    modeAmplitude,
+    normalMode,
     rendererStatus,
+    showModeArrows,
     surfaceMode,
+  ]);
+
+  useEffect(() => {
+    if (rendererStatus !== "ready" || !normalMode || !modePlaying) return;
+    const viewer = viewerRef.current;
+    if (!viewer) return;
+    let animationFrame = 0;
+    let previousTime: number | null = null;
+
+    const animate = (time: number) => {
+      if (document.hidden) {
+        previousTime = null;
+      } else {
+        if (previousTime !== null) {
+          const elapsed = Math.min(time - previousTime, 100);
+          modePhaseRef.current = (
+            modePhaseRef.current +
+            (elapsed / 1000) * modeSpeed * NORMAL_MODE_BASE_CYCLES_PER_SECOND * Math.PI * 2
+          ) % (Math.PI * 2);
+          setNormalModeFrame(viewer, modePhaseRef.current);
+        }
+        previousTime = time;
+      }
+      animationFrame = window.requestAnimationFrame(animate);
+    };
+    animationFrame = window.requestAnimationFrame(animate);
+    return () => window.cancelAnimationFrame(animationFrame);
+  }, [
+    modePlaying,
+    modeSpeed,
+    normalMode,
+    onModePhase,
+    rendererStatus,
+    setNormalModeFrame,
   ]);
 
   useEffect(() => {
@@ -469,7 +584,9 @@ function MolecularFieldCanvas({
   }, []);
 
   const activeField = fields[activeFieldIndex];
-  const description = activeField
+  const description = normalMode
+    ? `normal mode “${normalMode.label}” at ${frequencyLabel(normalMode.frequencyCm1)}`
+    : activeField
     ? `${FIELD_KIND_LABELS[activeField.kind]} “${activeField.label}” on ${activeField.shape.join(" by ")} grid points`
     : atoms.length > 0 ? "molecular geometry" : "an empty scene";
 
@@ -490,6 +607,7 @@ function MolecularFieldCanvas({
         </p>
       ) : null}
       <p className="viewer-canvas-hint" aria-hidden="true">
+        {normalMode ? "Normal-mode motion is visually scaled · " : ""}
         Drag to rotate · scroll to zoom · right-drag to pan
       </p>
     </div>
@@ -501,9 +619,14 @@ export function MoleculeViewer() {
   const [unit, setUnit] = useState<"angstrom" | "bohr">("angstrom");
   const [atoms, setAtoms] = useState<Atom[]>(() => parseGeometry(PRESETS.Water, "angstrom"));
   const [fields, setFields] = useState<VolumeField[]>([]);
-  const [vibration, setVibration] = useState<Vibration | null>(null);
-  const [vibrationPlaying, setVibrationPlaying] = useState(false);
   const [activeFieldIndex, setActiveFieldIndex] = useState(-1);
+  const [normalModes, setNormalModes] = useState<NormalMode[]>([]);
+  const [activeModeIndex, setActiveModeIndex] = useState(-1);
+  const [modeAmplitude, setModeAmplitude] = useState(0.25);
+  const [renderedModeAmplitude, setRenderedModeAmplitude] = useState(0.25);
+  const [modeSpeed, setModeSpeed] = useState(1);
+  const [modePlaying, setModePlaying] = useState(false);
+  const [showModeArrows, setShowModeArrows] = useState(true);
   const [surfaceMode, setSurfaceMode] = useState<SurfaceMode>("hidden");
   const [isovalue, setIsovalue] = useState(0.02);
   const [sceneTitle, setSceneTitle] = useState("Water");
@@ -514,9 +637,16 @@ export function MoleculeViewer() {
   const [autoRotate, setAutoRotate] = useState(false);
   const [isDraggingFile, setIsDraggingFile] = useState(false);
   const [resetSignal, setResetSignal] = useState(0);
+  const [modePhaseRequest, setModePhaseRequest] = useState({ phase: 0, serial: 0 });
+  const [modePhaseScale, setModePhaseScale] = useState(0);
+  const reducedMotionRef = useRef(false);
+  const initialAutoRotateBlockedRef = useRef(false);
+  const modePhaseRef = useRef(0);
+  const modeAmplitudeTimerRef = useRef<number | null>(null);
   const bonds = useMemo(() => inferBonds(atoms), [atoms]);
   const formula = useMemo(() => formulaFor(atoms), [atoms]);
   const activeField = fields[activeFieldIndex];
+  const activeNormalMode = normalModes[activeModeIndex];
   const activeEsp = activeField?.kind === "electron-density"
     ? espForDensity(activeField, fields)
     : undefined;
@@ -525,16 +655,62 @@ export function MoleculeViewer() {
     : undefined;
   const renderedIsovalue = useDeferredValue(isovalue);
 
+  const clearModeAmplitudeTimer = useCallback(() => {
+    if (modeAmplitudeTimerRef.current !== null) {
+      window.clearTimeout(modeAmplitudeTimerRef.current);
+      modeAmplitudeTimerRef.current = null;
+    }
+  }, []);
+
+  const replaceModeAmplitude = useCallback((value: number) => {
+    clearModeAmplitudeTimer();
+    setModeAmplitude(value);
+    setRenderedModeAmplitude(value);
+  }, [clearModeAmplitudeTimer]);
+
+  const scheduleModeAmplitude = useCallback((value: number) => {
+    setModeAmplitude(value);
+    clearModeAmplitudeTimer();
+    modeAmplitudeTimerRef.current = window.setTimeout(() => {
+      setRenderedModeAmplitude(value);
+      modeAmplitudeTimerRef.current = null;
+    }, 120);
+  }, [clearModeAmplitudeTimer]);
+
+  const resetModePhase = useCallback(() => {
+    modePhaseRef.current = 0;
+    setModePhaseScale(0);
+    setModePhaseRequest((request) => ({ phase: 0, serial: request.serial + 1 }));
+  }, []);
+
+  const scrubModePhase = useCallback((displacementScale: number) => {
+    const normalizedScale = Math.max(-1, Math.min(1, displacementScale));
+    const phase = Math.asin(normalizedScale);
+    modePhaseRef.current = phase;
+    setModePhaseScale(normalizedScale);
+    setModePhaseRequest((request) => ({ phase, serial: request.serial + 1 }));
+  }, []);
+
+  useEffect(() => clearModeAmplitudeTimer, [clearModeAmplitudeTimer]);
+
   useEffect(() => {
     const reducedMotion = typeof window.matchMedia === "function"
       ? window.matchMedia("(prefers-reduced-motion: reduce)")
       : null;
+    reducedMotionRef.current = reducedMotion?.matches ?? false;
     const frame = window.requestAnimationFrame(() => {
-      if (!reducedMotion?.matches) setAutoRotate(true);
+      if (!reducedMotionRef.current && !initialAutoRotateBlockedRef.current) {
+        setAutoRotate(true);
+      }
     });
     if (!reducedMotion) return () => window.cancelAnimationFrame(frame);
     const disableAnimation = (event: MediaQueryListEvent) => {
-      if (event.matches) setAutoRotate(false);
+      reducedMotionRef.current = event.matches;
+      if (event.matches) {
+        setAutoRotate(false);
+        setModePhaseScale(Math.sin(modePhaseRef.current));
+        setModePlaying(false);
+      }
     };
     reducedMotion.addEventListener("change", disableAnimation);
     return () => {
@@ -548,27 +724,64 @@ export function MoleculeViewer() {
     setActiveFieldIndex(nextField ? nextIndex : -1);
     setSurfaceMode(defaultSurface(nextField));
     setIsovalue(initialIsovalue(nextField, nextFields));
-  }, [fields]);
+    if (nextField) {
+      setActiveModeIndex(-1);
+      setModePlaying(false);
+      resetModePhase();
+    }
+  }, [fields, resetModePhase]);
+
+  const chooseNormalMode = useCallback((nextIndex: number) => {
+    const nextMode = normalModes[nextIndex];
+    setActiveModeIndex(nextMode ? nextIndex : -1);
+    setModePlaying(Boolean(nextMode) && !reducedMotionRef.current);
+    resetModePhase();
+    if (nextMode) {
+      setActiveFieldIndex(-1);
+      setSurfaceMode("hidden");
+      setAutoRotate(false);
+      setStatus(`Showing ${nextMode.label} at ${frequencyLabel(nextMode.frequencyCm1)}`);
+    }
+  }, [normalModes, resetModePhase]);
+
+  const updateModePhase = useCallback((phase: number) => {
+    modePhaseRef.current = phase;
+  }, []);
 
   const applyScene = useCallback((scene: ValidatedScene, nextStatus: string) => {
     setAtoms(scene.atoms);
     setSource(scene.molecule?.xyz ?? "");
     setUnit("angstrom");
     setFields(scene.fields);
-    setVibration(scene.vibration);
-    setVibrationPlaying(scene.vibration !== null);
     setSceneTitle(scene.title);
     setMode(scene.molecule?.representation ?? "ball-stick");
     setLabels(scene.molecule?.labels ?? false);
-    if (scene.vibration) setAutoRotate(false);
     setError(null);
     setStatus(nextStatus);
-    const nextField = scene.fields[scene.activeFieldIndex];
-    setActiveFieldIndex(nextField ? scene.activeFieldIndex : -1);
-    setSurfaceMode(defaultSurface(nextField));
-    setIsovalue(initialIsovalue(nextField, scene.fields));
+    const nextModes = scene.normalModes?.modes ?? [];
+    const nextMode = scene.normalModes
+      ? nextModes[scene.normalModes.activeModeIndex]
+      : undefined;
+    initialAutoRotateBlockedRef.current = Boolean(nextMode);
+    setNormalModes(nextModes);
+    setActiveModeIndex(nextMode ? (scene.normalModes?.activeModeIndex ?? -1) : -1);
+    replaceModeAmplitude(scene.normalModes?.amplitudeAngstrom ?? 0.25);
+    setModeSpeed(1);
+    setShowModeArrows(true);
+    setModePlaying(Boolean(nextMode) && !reducedMotionRef.current);
+    resetModePhase();
+    if (nextMode) {
+      setActiveFieldIndex(-1);
+      setSurfaceMode("hidden");
+      setAutoRotate(false);
+    } else {
+      const nextField = scene.fields[scene.activeFieldIndex];
+      setActiveFieldIndex(nextField ? scene.activeFieldIndex : -1);
+      setSurfaceMode(defaultSurface(nextField));
+      setIsovalue(initialIsovalue(nextField, scene.fields));
+    }
     setResetSignal((value) => value + 1);
-  }, []);
+  }, [replaceModeAmplitude, resetModePhase]);
 
   useEffect(() => {
     const frame = window.requestAnimationFrame(() => {
@@ -582,9 +795,11 @@ export function MoleculeViewer() {
         setSource(geometry);
         setUnit("angstrom");
         setFields([]);
-        setVibration(null);
-        setVibrationPlaying(false);
         setActiveFieldIndex(-1);
+        setNormalModes([]);
+        setActiveModeIndex(-1);
+        setModePlaying(false);
+        resetModePhase();
         setSurfaceMode("hidden");
         setSceneTitle("Linked geometry");
         setStatus("Geometry loaded from link");
@@ -609,7 +824,7 @@ export function MoleculeViewer() {
     });
 
     return () => window.cancelAnimationFrame(frame);
-  }, []);
+  }, [resetModePhase]);
 
   useEffect(() => {
     function receiveScene(event: MessageEvent<unknown>) {
@@ -628,11 +843,20 @@ export function MoleculeViewer() {
       }
       try {
         const scene = validateSceneMessage(event.data);
+        const surfaceCount = scene.fields.length;
+        const modeCount = scene.normalModes?.modes.length ?? 0;
+        const parts: string[] = [];
+        if (surfaceCount > 0) {
+          parts.push(`${surfaceCount} ${surfaceCount === 1 ? "surface" : "states / surfaces"}`);
+        }
+        if (modeCount > 0) {
+          parts.push(`${modeCount} normal ${modeCount === 1 ? "mode" : "modes"}`);
+        }
         applyScene(
           scene,
-          scene.vibration
-            ? `Normal mode ${scene.vibration.modeIndex} received from PyQED`
-            : `${scene.fields.length} ${scene.fields.length === 1 ? "surface" : "states / surfaces"} received from PyQED`,
+          parts.length > 0
+            ? `${parts.join(" · ")} received from PyQED`
+            : "Geometry received from PyQED",
         );
       } catch (sceneError) {
         setError(
@@ -667,9 +891,11 @@ export function MoleculeViewer() {
     try {
       setAtoms(parseGeometry(nextSource, nextUnit));
       setFields([]);
-      setVibration(null);
-      setVibrationPlaying(false);
       setActiveFieldIndex(-1);
+      setNormalModes([]);
+      setActiveModeIndex(-1);
+      setModePlaying(false);
+      resetModePhase();
       setSurfaceMode("hidden");
       setSceneTitle(nextTitle);
       setStatus("Geometry updated");
@@ -714,9 +940,11 @@ export function MoleculeViewer() {
         setUnit("angstrom");
         setAtoms(nextAtoms);
         setFields([]);
-        setVibration(null);
-        setVibrationPlaying(false);
         setActiveFieldIndex(-1);
+        setNormalModes([]);
+        setActiveModeIndex(-1);
+        setModePlaying(false);
+        resetModePhase();
         setSurfaceMode("hidden");
         setSceneTitle(file.name.replace(/\.xyz$/i, ""));
         setStatus(`Geometry loaded from ${file.name}`);
@@ -752,10 +980,23 @@ export function MoleculeViewer() {
 
   function downloadXyz() {
     if (atoms.length === 0) return;
-    const url = URL.createObjectURL(new Blob([xyzFor(atoms)], { type: "chemical/x-xyz" }));
+    const exportAtoms = activeNormalMode
+      ? displacedAtoms(
+          atoms,
+          activeNormalMode,
+          renderedModeAmplitude,
+          modePhaseRef.current,
+        )
+      : atoms;
+    const comment = activeNormalMode
+      ? `${activeNormalMode.label} · displayed normal-mode displacement`
+      : "Exported from the PyQED molecular viewer";
+    const url = URL.createObjectURL(
+      new Blob([xyzFor(exportAtoms, comment)], { type: "chemical/x-xyz" }),
+    );
     const anchor = document.createElement("a");
     anchor.href = url;
-    anchor.download = `${formula.toLowerCase() || "molecule"}.xyz`;
+    anchor.download = `${formula.toLowerCase() || "molecule"}${activeNormalMode ? `-${activeNormalMode.name}` : ""}.xyz`;
     anchor.click();
     URL.revokeObjectURL(url);
   }
@@ -835,17 +1076,17 @@ export function MoleculeViewer() {
         <div className="volume-input-note">
           <span>02</span>
           <div>
-            <strong>Scalar fields</strong>
+            <strong>Scalar fields + normal modes</strong>
             <p>
               Drop a Gaussian cube file onto the viewer, or call <code>view(...)</code> in
-              PyQED. Multi-state files remain selectable and never enter the page URL.
+              PyQED. Multi-state files remain selectable, and vibrational modes never enter the page URL.
             </p>
           </div>
         </div>
       </aside>
 
       <div
-        className={`viewer-display-panel${isDraggingFile ? " is-file-dragging" : ""}`}
+        className={`viewer-display-panel${normalModes.length > 0 ? " has-normal-modes" : ""}${isDraggingFile ? " is-file-dragging" : ""}`}
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
@@ -853,16 +1094,15 @@ export function MoleculeViewer() {
         <div className="viewer-toolbar">
           <div className="molecule-identity">
             <span>
-              {vibration ? "Normal mode" : activeField ? FIELD_KIND_LABELS[activeField.kind] : "Live structure"}
+              {activeNormalMode
+                ? "Normal mode"
+                : activeField ? FIELD_KIND_LABELS[activeField.kind] : "Live structure"}
             </span>
-            <strong>
-              {vibration
-                ? `Mode ${vibration.modeIndex} · ${vibration.frequencyCm1.toFixed(1)} cm⁻¹`
-                : activeField?.label ?? formula}
-            </strong>
+            <strong>{activeNormalMode?.label ?? activeField?.label ?? formula}</strong>
             <small>
               {sceneTitle} · {atoms.length} atoms · {bonds.length} inferred bonds
               {fields.length > 0 ? ` · ${fields.length} ${fields.length === 1 ? "surface" : "states / surfaces"}` : ""}
+              {normalModes.length > 0 ? ` · ${normalModes.length} normal ${normalModes.length === 1 ? "mode" : "modes"}` : ""}
             </small>
           </div>
           <div className="viewer-controls" aria-label="Viewer controls">
@@ -935,6 +1175,8 @@ export function MoleculeViewer() {
               type="button"
               className={labels ? "is-active" : ""}
               aria-pressed={labels}
+              disabled={Boolean(activeNormalMode)}
+              title={activeNormalMode ? "Atom labels are hidden during normal-mode playback" : undefined}
               onClick={() => setLabels((value) => !value)}
             >
               Labels
@@ -943,38 +1185,144 @@ export function MoleculeViewer() {
               type="button"
               className={autoRotate ? "is-active" : ""}
               aria-pressed={autoRotate}
-              onClick={() => setAutoRotate((value) => !value)}
+              onClick={() => {
+                if (!autoRotate) {
+                  setModePhaseScale(Math.sin(modePhaseRef.current));
+                  setModePlaying(false);
+                }
+                setAutoRotate((value) => !value);
+              }}
             >
               Auto-rotate
             </button>
-            {vibration ? (
-              <button
-                type="button"
-                className={vibrationPlaying ? "is-active" : ""}
-                aria-pressed={vibrationPlaying}
-                onClick={() => setVibrationPlaying((value) => !value)}
-              >
-                {vibrationPlaying ? "Pause mode" : "Play mode"}
-              </button>
-            ) : null}
             <button type="button" onClick={() => setResetSignal((value) => value + 1)}>
               Reset view
             </button>
           </div>
         </div>
 
+        {normalModes.length > 0 ? (
+          <div className="normal-mode-panel" aria-label="Normal mode controls">
+            <label className="normal-mode-select">
+              Normal mode
+              <select
+                value={activeModeIndex}
+                onChange={(event) => chooseNormalMode(Number(event.target.value))}
+              >
+                <option value={-1}>No normal mode</option>
+                {normalModes.map((normalMode, index) => (
+                  <option key={normalMode.name} value={index}>
+                    {normalMode.label} · {frequencyLabel(normalMode.frequencyCm1)}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <div className="normal-mode-frequency" aria-live="polite">
+              <span>Frequency</span>
+              <strong>{activeNormalMode ? frequencyLabel(activeNormalMode.frequencyCm1) : "—"}</strong>
+              {activeNormalMode && activeNormalMode.frequencyCm1 < 0 ? (
+                <em>Imaginary mode</em>
+              ) : null}
+            </div>
+            <button
+              type="button"
+              className={`normal-mode-play${modePlaying ? " is-active" : ""}`}
+              aria-pressed={modePlaying}
+              disabled={!activeNormalMode}
+              onClick={() => {
+                if (modePlaying) {
+                  setModePhaseScale(Math.sin(modePhaseRef.current));
+                }
+                setModePlaying((value) => {
+                  if (!value) setAutoRotate(false);
+                  return !value;
+                });
+              }}
+            >
+              {modePlaying ? "Pause" : "Play"}
+            </button>
+            <label className="normal-mode-slider">
+              <span>Amplitude <output>{modeAmplitude.toFixed(2)} Å</output></span>
+              <input
+                type="range"
+                min="0.01"
+                max="10"
+                step="0.01"
+                value={modeAmplitude}
+                disabled={!activeNormalMode}
+                onChange={(event) => scheduleModeAmplitude(Number(event.target.value))}
+                onPointerUp={(event) => replaceModeAmplitude(Number(event.currentTarget.value))}
+                onKeyUp={(event) => replaceModeAmplitude(Number(event.currentTarget.value))}
+                onBlur={(event) => replaceModeAmplitude(Number(event.currentTarget.value))}
+              />
+            </label>
+            <label className="normal-mode-slider">
+              <span>
+                Mode phase <output>{modePlaying ? "Playing" : `${(modePhaseScale * 100).toFixed(0)}%`}</output>
+              </span>
+              <input
+                type="range"
+                min="-1"
+                max="1"
+                step={1 / (NORMAL_MODE_FRAME_STEPS - 1)}
+                value={modePhaseScale}
+                disabled={!activeNormalMode || modePlaying}
+                title={modePlaying ? "Pause playback to scrub the mode phase" : undefined}
+                onChange={(event) => scrubModePhase(Number(event.target.value))}
+              />
+            </label>
+            <label className="normal-mode-slider">
+              <span>Playback speed <output>{modeSpeed.toFixed(2)}×</output></span>
+              <input
+                type="range"
+                min="0.25"
+                max="2"
+                step="0.05"
+                value={modeSpeed}
+                disabled={!activeNormalMode}
+                onChange={(event) => setModeSpeed(Number(event.target.value))}
+              />
+            </label>
+            <button
+              type="button"
+              className={showModeArrows ? "is-active" : ""}
+              aria-pressed={showModeArrows}
+              disabled={!activeNormalMode}
+              onClick={() => setShowModeArrows((value) => !value)}
+            >
+              Displacement arrows
+            </button>
+            {activeNormalMode ? (
+              <p className="normal-mode-details">
+                {activeNormalMode.reducedMassAmu !== undefined
+                  ? `Reduced mass ${activeNormalMode.reducedMassAmu.toPrecision(4)} amu · `
+                  : ""}
+                {activeNormalMode.intensity !== undefined
+                  ? `Intensity ${activeNormalMode.intensity.toPrecision(4)}${activeNormalMode.intensityUnit ? ` ${activeNormalMode.intensityUnit}` : ""} · `
+                  : ""}
+                Visual amplitude is scaled; the overall arrow direction is arbitrary.
+              </p>
+            ) : null}
+          </div>
+        ) : null}
+
         <MolecularFieldCanvas
           atoms={atoms}
           fields={fields}
           activeFieldIndex={activeFieldIndex}
+          normalMode={activeNormalMode}
+          modeAmplitude={renderedModeAmplitude}
+          modeSpeed={modeSpeed}
+          modePlaying={modePlaying}
+          modePhaseRequest={modePhaseRequest}
+          showModeArrows={showModeArrows}
+          onModePhase={updateModePhase}
           mode={mode}
           labels={labels}
           autoRotate={autoRotate}
           surfaceMode={surfaceMode}
           isovalue={renderedIsovalue}
           resetSignal={resetSignal}
-          vibration={vibration}
-          vibrationPlaying={vibrationPlaying}
         />
 
         {isDraggingFile ? (
@@ -1007,11 +1355,14 @@ export function MoleculeViewer() {
               {activeField && surfaceMode === "esp-map" ? (
                 <span className="esp-gradient-key"><i />negative ESP · neutral · positive ESP</span>
               ) : null}
+              {activeNormalMode && showModeArrows ? (
+                <span><i className="normal-mode-vector" />normalized displacement vector</span>
+              ) : null}
             </div>
             <p className="viewer-file-status" aria-live="polite">{status}</p>
           </div>
           <button type="button" className="export-button" onClick={downloadXyz} disabled={atoms.length === 0}>
-            Export XYZ <span aria-hidden="true">↓</span>
+            {activeNormalMode ? "Export displaced XYZ" : "Export XYZ"} <span aria-hidden="true">↓</span>
           </button>
         </div>
       </div>

--- a/website/app/viewer/volume-data.d.mts
+++ b/website/app/viewer/volume-data.d.mts
@@ -31,6 +31,25 @@ export type VolumeField = {
   range: [number, number];
 };
 
+export type NormalMode = {
+  name: string;
+  label: string;
+  sourceIndex?: number;
+  frequencyCm1: number;
+  shape: [number, 3];
+  displacements: Float32Array;
+  normalization: "max-atom-displacement";
+  reducedMassAmu?: number;
+  intensity?: number;
+  intensityUnit?: string;
+};
+
+export type NormalModeCollection = {
+  modes: NormalMode[];
+  activeModeIndex: number;
+  amplitudeAngstrom: number;
+};
+
 export type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
 
 export type ValidatedScene = {
@@ -41,27 +60,32 @@ export type ValidatedScene = {
     representation: "ball-stick" | "space-fill" | "wireframe";
     labels: boolean;
   } | null;
-  vibration: {
-    modeIndex: number;
-    frequencyCm1: number;
-    displacements: [number, number, number][];
-    amplitudeAngstrom: number;
-    frames: number;
-    interval: number;
-  } | null;
   fields: VolumeField[];
   activeFieldIndex: number;
+  normalModes: NormalModeCollection | null;
 };
 
 export const BOHR_TO_ANGSTROM: number;
 export const MAX_ATOMS: number;
 export const MAX_FIELDS: number;
+export const MAX_NORMAL_MODES: number;
+export const MAX_NORMAL_MODE_COMPONENTS: number;
 export const MAX_GRID_POINTS: number;
 export const MAX_TOTAL_GRID_POINTS: number;
 export const MAX_CUBE_FILE_BYTES: number;
 
 export function parseGeometry(text: string, unit?: "angstrom" | "bohr"): Atom[];
 export function xyzFor(atoms: Atom[], comment?: string): string;
+export function displacedAtoms(
+  atoms: Atom[],
+  mode: NormalMode | undefined,
+  amplitudeAngstrom: number,
+  phase: number,
+): Atom[];
+export function symmetricNormalModeFrame(
+  phase: number,
+  frameSteps?: number,
+): { frame: number; displacementScale: number };
 export function validateSceneMessage(message: unknown): ValidatedScene;
 export function parseCube(text: string, options?: { fileName?: string }): ValidatedScene;
 export function suggestIsovalue(values: Iterable<number>, kind?: FieldKind): number;

--- a/website/app/viewer/volume-data.mjs
+++ b/website/app/viewer/volume-data.mjs
@@ -1,12 +1,15 @@
 export const BOHR_TO_ANGSTROM = 0.529177210903;
 export const MAX_ATOMS = 500;
 export const MAX_FIELDS = 512;
+export const MAX_NORMAL_MODES = 512;
+export const MAX_NORMAL_MODE_COMPONENTS = 768_000;
 export const MAX_GRID_POINTS = 2_000_000;
 export const MAX_TOTAL_GRID_POINTS = 8_000_000;
 export const MAX_CUBE_FILE_BYTES = 80_000_000;
 
 const MAX_GEOMETRY_CHARS = 1_000_000;
 const MAX_FLOAT32 = 3.4028234663852886e38;
+const MIN_NORMAL_MODE_NORM = 1.1754943508222875e-38;
 const FIELD_KINDS = new Set([
   "orbital",
   "electron-density",
@@ -228,9 +231,9 @@ export function xyzFor(atoms, comment = "Exported from the PyQED molecular viewe
   return `${atoms.length}\n${comment} · coordinates in angstrom\n${rows.join("\n")}\n`;
 }
 
-function decodeFloat32Base64(value, pointCount, context) {
+function decodeFloat32Base64(value, pointCount, context, encodingName = "value_encoding") {
   if (typeof value !== "string") {
-    fail(`${context} must be base64 text when value_encoding is float32-le-base64.`);
+    fail(`${context} must be base64 text when ${encodingName} is float32-le-base64.`);
   }
   const byteLength = pointCount * Float32Array.BYTES_PER_ELEMENT;
   const expectedLength = Math.ceil(byteLength / 3) * 4;
@@ -274,6 +277,183 @@ function decodeFloat32Base64(value, pointCount, context) {
     values[index] = data.getFloat32(index * Float32Array.BYTES_PER_ELEMENT, true);
   }
   return values;
+}
+
+function validateNormalMode(rawMode, index, atomCount) {
+  const context = `scene.normal_modes.modes[${index}]`;
+  if (!isRecord(rawMode)) fail(`${context} must be an object.`);
+  assertAllowedKeys(
+    rawMode,
+    new Set([
+      "name", "label", "source_index", "frequency_cm1", "shape",
+      "displacements", "displacement_encoding", "normalization",
+      "reduced_mass_amu", "intensity", "intensity_unit",
+    ]),
+    context,
+  );
+
+  const name = cleanLine(rawMode.name, `${context}.name`, 80);
+  const label = cleanLine(rawMode.label, `${context}.label`, 120, name);
+  let sourceIndex;
+  if (rawMode.source_index !== undefined) {
+    if (!Number.isSafeInteger(rawMode.source_index) || rawMode.source_index < 0) {
+      fail(`${context}.source_index must be a non-negative integer.`);
+    }
+    sourceIndex = rawMode.source_index;
+  }
+  const frequencyCm1 = finiteNumber(rawMode.frequency_cm1, `${context}.frequency_cm1`);
+  if (
+    !Array.isArray(rawMode.shape) ||
+    rawMode.shape.length !== 2 ||
+    rawMode.shape[0] !== atomCount ||
+    rawMode.shape[1] !== 3
+  ) {
+    fail(`${context}.shape must be [${atomCount}, 3] to match the molecule.`);
+  }
+  if (rawMode.displacement_encoding !== "float32-le-base64") {
+    fail(`${context}.displacement_encoding must be float32-le-base64.`);
+  }
+  if (rawMode.normalization !== "max-atom-displacement") {
+    fail(`${context}.normalization must be max-atom-displacement.`);
+  }
+
+  const componentCount = atomCount * 3;
+  const decoded = decodeFloat32Base64(
+    rawMode.displacements,
+    componentCount,
+    `${context}.displacements`,
+    "displacement_encoding",
+  );
+  let maximumNorm = 0;
+  for (let atomIndex = 0; atomIndex < atomCount; atomIndex += 1) {
+    const offset = atomIndex * 3;
+    const x = finiteNumber(decoded[offset], `${context}.displacements[${offset}]`);
+    const y = finiteNumber(decoded[offset + 1], `${context}.displacements[${offset + 1}]`);
+    const z = finiteNumber(decoded[offset + 2], `${context}.displacements[${offset + 2}]`);
+    maximumNorm = Math.max(maximumNorm, Math.hypot(x, y, z));
+  }
+  if (!(maximumNorm > MIN_NORMAL_MODE_NORM)) {
+    fail(`${context}.displacements cannot be all zero.`);
+  }
+
+  // Python emits max-atom-normalized vectors. Renormalizing here keeps the
+  // browser amplitude meaningful after float32 serialization or custom input.
+  const displacements = new Float32Array(componentCount);
+  for (let component = 0; component < componentCount; component += 1) {
+    displacements[component] = decoded[component] / maximumNorm;
+  }
+
+  let reducedMassAmu;
+  if (rawMode.reduced_mass_amu !== undefined) {
+    reducedMassAmu = finiteNumber(rawMode.reduced_mass_amu, `${context}.reduced_mass_amu`);
+    if (reducedMassAmu <= 0) fail(`${context}.reduced_mass_amu must be greater than zero.`);
+  }
+  let intensity;
+  if (rawMode.intensity !== undefined) {
+    intensity = finiteNumber(rawMode.intensity, `${context}.intensity`);
+    if (intensity < 0) fail(`${context}.intensity cannot be negative.`);
+  }
+  let intensityUnit;
+  if (rawMode.intensity_unit !== undefined) {
+    intensityUnit = cleanLine(rawMode.intensity_unit, `${context}.intensity_unit`, 40);
+    if (intensity === undefined) fail(`${context}.intensity_unit requires intensity.`);
+  }
+
+  return {
+    name,
+    label,
+    sourceIndex,
+    frequencyCm1,
+    shape: [atomCount, 3],
+    displacements,
+    normalization: "max-atom-displacement",
+    reducedMassAmu,
+    intensity,
+    intensityUnit,
+  };
+}
+
+function validateNormalModes(rawNormalModes, atomCount) {
+  const context = "scene.normal_modes";
+  if (!isRecord(rawNormalModes)) fail(`${context} must be an object.`);
+  assertAllowedKeys(
+    rawNormalModes,
+    new Set(["modes", "active_mode", "amplitude_angstrom"]),
+    context,
+  );
+  if (atomCount === 0) fail(`${context} requires a molecular geometry.`);
+  if (
+    !Array.isArray(rawNormalModes.modes) ||
+    rawNormalModes.modes.length === 0 ||
+    rawNormalModes.modes.length > MAX_NORMAL_MODES
+  ) {
+    fail(`${context}.modes must contain between 1 and ${MAX_NORMAL_MODES} modes.`);
+  }
+  const componentCount = rawNormalModes.modes.length * atomCount * 3;
+  if (componentCount > MAX_NORMAL_MODE_COMPONENTS) {
+    fail(`${context} exceeds the ${MAX_NORMAL_MODE_COMPONENTS.toLocaleString()}-component limit.`);
+  }
+  const modes = rawNormalModes.modes.map((mode, index) =>
+    validateNormalMode(mode, index, atomCount),
+  );
+  const names = new Set();
+  for (const mode of modes) {
+    if (names.has(mode.name)) fail(`Normal mode name “${mode.name}” is duplicated.`);
+    names.add(mode.name);
+  }
+
+  let activeModeIndex = 0;
+  if (rawNormalModes.active_mode !== undefined && rawNormalModes.active_mode !== null) {
+    if (Number.isInteger(rawNormalModes.active_mode)) {
+      activeModeIndex = rawNormalModes.active_mode;
+    } else if (typeof rawNormalModes.active_mode === "string") {
+      activeModeIndex = modes.findIndex((mode) => mode.name === rawNormalModes.active_mode);
+    } else {
+      fail(`${context}.active_mode must be a mode name or integer index.`);
+    }
+    if (activeModeIndex < 0 || activeModeIndex >= modes.length) {
+      fail(`${context}.active_mode does not identify a supplied mode.`);
+    }
+  }
+
+  const amplitudeAngstrom = rawNormalModes.amplitude_angstrom === undefined
+    ? 0.25
+    : finiteNumber(rawNormalModes.amplitude_angstrom, `${context}.amplitude_angstrom`);
+  if (amplitudeAngstrom < 0.01 || amplitudeAngstrom > 10) {
+    fail(`${context}.amplitude_angstrom must be between 0.01 and 10.`);
+  }
+  return { modes, activeModeIndex, amplitudeAngstrom };
+}
+
+export function displacedAtoms(atoms, mode, amplitudeAngstrom, phase) {
+  if (!mode) return atoms.map((atom) => ({ ...atom }));
+  if (!Number.isFinite(amplitudeAngstrom) || amplitudeAngstrom < 0) {
+    fail("Normal-mode amplitude must be a non-negative finite number.");
+  }
+  if (!Number.isFinite(phase)) fail("Normal-mode phase must be finite.");
+  if (mode.displacements.length !== atoms.length * 3) {
+    fail("Normal-mode displacements do not match the molecule.");
+  }
+  const scale = amplitudeAngstrom * Math.sin(phase);
+  return atoms.map((atom, index) => ({
+    ...atom,
+    x: atom.x + mode.displacements[index * 3] * scale,
+    y: atom.y + mode.displacements[index * 3 + 1] * scale,
+    z: atom.z + mode.displacements[index * 3 + 2] * scale,
+  }));
+}
+
+export function symmetricNormalModeFrame(phase, frameSteps = 30) {
+  if (!Number.isFinite(phase)) fail("Normal-mode phase must be finite.");
+  if (!Number.isSafeInteger(frameSteps) || frameSteps < 2) {
+    fail("Normal-mode frame steps must be an integer of at least two.");
+  }
+  const symmetricSteps = frameSteps - 1;
+  const displacementStep = Math.round(Math.sin(phase) * symmetricSteps);
+  return {
+    frame: frameSteps + displacementStep,
+    displacementScale: displacementStep / symmetricSteps,
+  };
 }
 
 function validateField(rawField, index) {
@@ -427,53 +607,6 @@ function validateField(rawField, index) {
   };
 }
 
-function validateVibration(rawVibration, atomCount) {
-  const context = "message.scene.vibration";
-  if (!isRecord(rawVibration)) fail(`${context} must be an object.`);
-  assertAllowedKeys(
-    rawVibration,
-    new Set([
-      "mode_index", "frequency_cm1", "displacements", "amplitude_angstrom",
-      "frames", "interval",
-    ]),
-    context,
-  );
-  const modeIndex = rawVibration.mode_index;
-  if (!Number.isSafeInteger(modeIndex) || modeIndex < 0) {
-    fail(`${context}.mode_index must be a non-negative integer.`);
-  }
-  const frequencyCm1 = finiteNumber(rawVibration.frequency_cm1, `${context}.frequency_cm1`);
-  const amplitudeAngstrom = finiteNumber(
-    rawVibration.amplitude_angstrom,
-    `${context}.amplitude_angstrom`,
-  );
-  if (amplitudeAngstrom <= 0 || amplitudeAngstrom > 10) {
-    fail(`${context}.amplitude_angstrom must be greater than zero and at most 10.`);
-  }
-  if (!Array.isArray(rawVibration.displacements) || rawVibration.displacements.length !== atomCount) {
-    fail(`${context}.displacements must contain one vector per atom.`);
-  }
-  const displacements = rawVibration.displacements.map((vector, index) =>
-    finiteVector(vector, `${context}.displacements[${index}]`),
-  );
-  const frames = rawVibration.frames;
-  if (!Number.isSafeInteger(frames) || frames < 8 || frames > 120) {
-    fail(`${context}.frames must be an integer between 8 and 120.`);
-  }
-  const interval = rawVibration.interval;
-  if (!Number.isSafeInteger(interval) || interval < 16 || interval > 1000) {
-    fail(`${context}.interval must be an integer between 16 and 1000 milliseconds.`);
-  }
-  return {
-    modeIndex,
-    frequencyCm1,
-    displacements,
-    amplitudeAngstrom,
-    frames,
-    interval,
-  };
-}
-
 export function validateSceneMessage(message) {
   if (!isRecord(message)) fail("The PyQED message must be an object.");
   assertAllowedKeys(message, new Set(["type", "scene"]), "message");
@@ -482,7 +615,10 @@ export function validateSceneMessage(message) {
   const scene = message.scene;
   assertAllowedKeys(
     scene,
-    new Set(["version", "kind", "title", "molecule", "fields", "active_field", "vibration"]),
+    new Set([
+      "version", "kind", "title", "molecule", "fields", "active_field",
+      "normal_modes",
+    ]),
     "message.scene",
   );
   if (scene.version !== 1 || scene.kind !== "pyqed-scene") {
@@ -507,12 +643,6 @@ export function validateSceneMessage(message) {
     molecule = { xyz, representation, labels };
   }
 
-  let vibration = null;
-  if (scene.vibration !== undefined && scene.vibration !== null) {
-    if (!molecule) fail("message.scene.vibration requires a molecule.");
-    vibration = validateVibration(scene.vibration, atoms.length);
-  }
-
   if (!Array.isArray(scene.fields) || scene.fields.length > MAX_FIELDS) {
     fail(`message.scene.fields must be an array with at most ${MAX_FIELDS} entries.`);
   }
@@ -526,7 +656,6 @@ export function validateSceneMessage(message) {
     }
     fields.push(field);
   }
-  if (!molecule && fields.length === 0) fail("A scene must contain a molecule or at least one scalar field.");
   const names = new Set();
   for (const field of fields) {
     if (names.has(field.name)) fail(`Field name “${field.name}” is duplicated.`);
@@ -557,13 +686,23 @@ export function validateSceneMessage(message) {
     }
   }
 
+  const normalModes = scene.normal_modes === undefined
+    ? null
+    : validateNormalModes(scene.normal_modes, atoms.length);
+  if (normalModes && fields.length > 0) {
+    fail("Normal modes cannot be combined with scalar fields in one scene.");
+  }
+  if (!molecule && fields.length === 0 && !normalModes) {
+    fail("A scene must contain a molecule or at least one scalar field.");
+  }
+
   return {
     title,
     atoms,
     molecule,
-    vibration,
     fields,
     activeFieldIndex,
+    normalModes,
   };
 }
 
@@ -758,9 +897,9 @@ export function parseCube(text, options = {}) {
       representation: "ball-stick",
       labels: false,
     },
-    vibration: null,
     fields,
     activeFieldIndex: fields.length > 0 ? 0 : -1,
+    normalModes: null,
   };
 }
 

--- a/website/tests/rendered-html.test.mjs
+++ b/website/tests/rendered-html.test.mjs
@@ -4,9 +4,13 @@ import test from "node:test";
 import {
   BOHR_TO_ANGSTROM,
   MAX_GRID_POINTS,
+  MAX_NORMAL_MODE_COMPONENTS,
+  MAX_NORMAL_MODES,
+  displacedAtoms,
   fieldToCube,
   parseCube,
   parseGeometry,
+  symmetricNormalModeFrame,
   validateSceneMessage,
 } from "../app/viewer/volume-data.mjs";
 
@@ -326,54 +330,211 @@ test("validates encoded scalar fields and ESP density mappings", () => {
   );
 });
 
-test("validates normal-mode scenes and atom-aligned displacements", () => {
+test("validates, normalizes, and displaces nested normal-mode scenes", () => {
+  const realMode = {
+    name: "mode-1",
+    label: "Symmetric stretch",
+    source_index: 5,
+    frequency_cm1: 1595.23,
+    shape: [2, 3],
+    displacements: float32Base64([2, 0, 0, 0, 1, 0]),
+    displacement_encoding: "float32-le-base64",
+    normalization: "max-atom-displacement",
+    reduced_mass_amu: 1.234,
+    intensity: 42.5,
+    intensity_unit: "km mol^-1",
+  };
+  const imaginaryMode = {
+    ...realMode,
+    name: "mode-2",
+    label: "Reaction coordinate",
+    source_index: 6,
+    frequency_cm1: -462.75,
+    displacements: float32Base64([0, 0, 1, 0, 0, -1]),
+    reduced_mass_amu: undefined,
+    intensity: undefined,
+    intensity_unit: undefined,
+  };
   const message = {
     type: "pyqed:scene",
     scene: {
       version: 1,
       kind: "pyqed-scene",
-      title: "Mode 0: 4401.2 cm^-1",
-      molecule: {
-        xyz: "2\nH2\nH 0 0 -0.37\nH 0 0 0.37",
-        representation: "ball-stick",
-        labels: false,
-      },
-      vibration: {
-        mode_index: 0,
-        frequency_cm1: 4401.2,
-        displacements: [[0, 0, -0.15], [0, 0, 0.15]],
-        amplitude_angstrom: 0.15,
-        frames: 24,
-        interval: 60,
-      },
+      molecule: { xyz: "H 0 0 0; H 0 0 0.74" },
       fields: [],
-      active_field: null,
+      normal_modes: {
+        modes: [realMode, imaginaryMode],
+        active_mode: "mode-2",
+        amplitude_angstrom: 0.6,
+      },
     },
   };
 
   const scene = validateSceneMessage(message);
-  assert.equal(scene.vibration.modeIndex, 0);
-  assert.equal(scene.vibration.frequencyCm1, 4401.2);
-  assert.deepEqual(scene.vibration.displacements[1], [0, 0, 0.15]);
-  assert.equal(scene.vibration.frames, 24);
+  assert.equal(scene.normalModes.activeModeIndex, 1);
+  assert.equal(scene.normalModes.amplitudeAngstrom, 0.6);
+  assert.equal(scene.normalModes.modes[0].sourceIndex, 5);
+  assert.equal(scene.normalModes.modes[1].frequencyCm1, -462.75);
+  assert.equal(scene.normalModes.modes[0].reducedMassAmu, 1.234);
+  assert.equal(scene.normalModes.modes[0].intensityUnit, "km mol^-1");
+  assert.ok(Math.abs(scene.normalModes.modes[0].displacements[0] - 1) < 1e-7);
+  assert.ok(Math.abs(scene.normalModes.modes[0].displacements[4] - 0.5) < 1e-7);
 
+  const equilibrium = displacedAtoms(scene.atoms, scene.normalModes.modes[0], 0.4, 0);
+  const positiveTurningPoint = displacedAtoms(
+    scene.atoms,
+    scene.normalModes.modes[0],
+    0.4,
+    Math.PI / 2,
+  );
+  assert.deepEqual(equilibrium, scene.atoms);
+  assert.ok(Math.abs(positiveTurningPoint[0].x - 0.4) < 1e-7);
+  assert.equal(scene.atoms[0].x, 0, "displacement helpers must not mutate equilibrium atoms");
+  assert.equal(MAX_NORMAL_MODES, 512);
+  assert.equal(MAX_NORMAL_MODE_COMPONENTS, 768_000);
+});
+
+test("maps normal-mode animation onto symmetric 3Dmol frames", () => {
+  assert.deepEqual(symmetricNormalModeFrame(0), {
+    frame: 30,
+    displacementScale: 0,
+  });
+  assert.deepEqual(symmetricNormalModeFrame(Math.PI / 2), {
+    frame: 59,
+    displacementScale: 1,
+  });
+  assert.deepEqual(symmetricNormalModeFrame(3 * Math.PI / 2), {
+    frame: 1,
+    displacementScale: -1,
+  });
+
+  for (const phase of [0.13, 0.47, 1.2, 2.1]) {
+    const positive = symmetricNormalModeFrame(phase);
+    const negative = symmetricNormalModeFrame(phase + Math.PI);
+    assert.equal(positive.frame + negative.frame, 60);
+    assert.ok(Math.abs(positive.displacementScale + negative.displacementScale) < 1e-12);
+    assert.ok(positive.frame >= 1 && positive.frame <= 59);
+  }
+  assert.throws(() => symmetricNormalModeFrame(Number.NaN), /phase must be finite/i);
+  assert.throws(() => symmetricNormalModeFrame(0, 1), /at least two/i);
+});
+
+test("rejects malformed or unsafe normal-mode payloads", () => {
+  const mode = {
+    name: "mode-1",
+    label: "Stretch",
+    source_index: 0,
+    frequency_cm1: 1000,
+    shape: [1, 3],
+    displacements: float32Base64([1, 0, 0]),
+    displacement_encoding: "float32-le-base64",
+    normalization: "max-atom-displacement",
+    reduced_mass_amu: 1,
+  };
+  const build = (normalModes, molecule = { xyz: "H 0 0 0" }) => ({
+    type: "pyqed:scene",
+    scene: {
+      version: 1,
+      kind: "pyqed-scene",
+      molecule,
+      fields: [],
+      normal_modes: normalModes,
+    },
+  });
+  const set = (overrides = {}) => ({
+    modes: [mode],
+    active_mode: 0,
+    amplitude_angstrom: 0.45,
+    ...overrides,
+  });
+
+  assert.throws(() => validateSceneMessage(build(set(), null)), /requires a molecular geometry/i);
+  assert.throws(
+    () => validateSceneMessage(build(null)),
+    /normal_modes must be an object/i,
+  );
+  assert.throws(
+    () => validateSceneMessage(build(set({ script: "alert(1)" }))),
+    /unsupported property/i,
+  );
+  assert.throws(
+    () => validateSceneMessage(build(set({ modes: [{ ...mode, shape: [2, 3] }] }))),
+    /shape must be \[1, 3\]/i,
+  );
+  assert.throws(
+    () => validateSceneMessage(build(set({ modes: [{ ...mode, displacements: "AAAA" }] }))),
+    /Float32 values require/i,
+  );
+  assert.throws(
+    () => validateSceneMessage(build(set({
+      modes: [{ ...mode, displacements: float32Base64([NaN, 0, 0]) }],
+    }))),
+    /finite 32-bit floating-point/i,
+  );
+  assert.throws(
+    () => validateSceneMessage(build(set({
+      modes: [{ ...mode, displacements: float32Base64([0, 0, 0]) }],
+    }))),
+    /cannot be all zero/i,
+  );
+  assert.throws(
+    () => validateSceneMessage(build(set({ modes: [mode, { ...mode }] }))),
+    /duplicated/i,
+  );
+  assert.throws(
+    () => validateSceneMessage(build(set({ modes: Array(MAX_NORMAL_MODES + 1).fill(mode) }))),
+    /between 1 and 512 modes/i,
+  );
+  assert.throws(
+    () => validateSceneMessage(build(set({ active_mode: "missing" }))),
+    /does not identify/i,
+  );
+  assert.throws(
+    () => validateSceneMessage(build(set({ modes: [{ ...mode, reduced_mass_amu: 0 }] }))),
+    /greater than zero/i,
+  );
+  assert.throws(
+    () => validateSceneMessage(build(set({ modes: [{ ...mode, source_index: 2 ** 53 }] }))),
+    /non-negative integer/i,
+  );
+  assert.throws(
+    () => validateSceneMessage(build(set({ modes: [{ ...mode, normalization: "unit-vector" }] }))),
+    /max-atom-displacement/i,
+  );
+  assert.throws(
+    () => validateSceneMessage(build(set({ modes: [{ ...mode, intensity_unit: "km mol^-1" }] }))),
+    /requires intensity/i,
+  );
+  assert.throws(
+    () => validateSceneMessage(build(set({ amplitude_angstrom: 0 }))),
+    /between 0\.01 and 10/i,
+  );
+  assert.throws(
+    () => validateSceneMessage(build(set({ amplitude_angstrom: 0.009 }))),
+    /between 0\.01 and 10/i,
+  );
   assert.throws(
     () => validateSceneMessage({
-      ...message,
+      ...build(set()),
       scene: {
-        ...message.scene,
-        vibration: { ...message.scene.vibration, displacements: [[0, 0, 0.1]] },
+        ...build(set()).scene,
+        fields: [{
+          name: "rho",
+          kind: "electron-density",
+          shape: [2, 2, 2],
+          origin: [0, 0, 0],
+          axes: [[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+          values: Array(8).fill(0),
+        }],
       },
     }),
-    /one vector per atom/i,
+    /cannot be combined with scalar fields/i,
   );
-  assert.throws(
-    () => validateSceneMessage({
-      ...message,
-      scene: { ...message.scene, molecule: null },
-    }),
-    /requires a molecule/i,
-  );
+
+  const { source_index: ignoredSourceIndex, ...withoutSourceIndex } = mode;
+  assert.equal(ignoredSourceIndex, 0);
+  const optionalSource = validateSceneMessage(build(set({ modes: [withoutSourceIndex] })));
+  assert.equal(optionalSource.normalModes.modes[0].sourceIndex, undefined);
 });
 
 test("parses single and multi-state Gaussian cube files in C order", () => {
@@ -458,8 +619,6 @@ test("uses a static, repository-owned deployment", async () => {
   assert.match(moleculeViewer, /validateSceneMessage\(event\.data\)/);
   assert.match(moleculeViewer, /import\("3dmol"\)/);
   assert.match(moleculeViewer, /pyqed:viewer-ready/);
-  assert.match(moleculeViewer, /viewer\.vibrate\(vibration\.frames/);
-  assert.match(moleculeViewer, /Pause mode/);
   assert.ok(
     moleculeViewer.indexOf('window.addEventListener("message", receiveScene)') <
       moleculeViewer.indexOf('type: "pyqed:viewer-ready"'),
@@ -467,14 +626,23 @@ test("uses a static, repository-owned deployment", async () => {
   );
   assert.match(moleculeViewer, /WeakMap<VolumeField, unknown>/);
   assert.equal((moleculeViewer.match(/new library\.VolumeData/g) ?? []).length, 1);
-  assert.match(
-    moleculeViewer,
-    /\}, \[\s*activeFieldIndex,\s*atoms,\s*fields,\s*isovalue,\s*rendererStatus,\s*surfaceMode,\s*\]\);/,
-  );
   assert.match(moleculeViewer, /useDeferredValue\(isovalue\)/);
   assert.match(moleculeViewer, /prefers-reduced-motion: reduce/);
+  assert.match(moleculeViewer, /viewer\.vibrate\(NORMAL_MODE_FRAME_STEPS, scaledModeAmplitude, true\)/);
+  assert.match(moleculeViewer, /viewer\.setFrame\(frame\)/);
+  assert.match(moleculeViewer, /viewer\.addArrow\(/);
+  assert.match(moleculeViewer, /window\.requestAnimationFrame\(animate\)/);
+  assert.match(moleculeViewer, /document\.hidden/);
+  assert.match(moleculeViewer, /renderedModeAmplitude/);
+  assert.match(moleculeViewer, /scheduleModeAmplitude/);
+  assert.match(moleculeViewer, /Mode phase/);
+  assert.match(moleculeViewer, /Imaginary mode/);
+  assert.match(moleculeViewer, /Displacement arrows/);
+  assert.match(moleculeViewer, /setActiveFieldIndex\(-1\);[\s\S]*setSurfaceMode\("hidden"\)/);
   assert.doesNotMatch(moleculeViewer, /https?:\/\/.*3dmol/i);
   assert.match(css, /\.file-button:focus-within/);
+  assert.match(css, /\.normal-mode-panel/);
+  assert.match(css, /grid-template-columns:\s*minmax\(0, 1\.25fr\) repeat\(3, minmax\(0, 1fr\)\)/);
   assert.match(css, /animation-duration:\s*0\.01ms\s*!important/);
 
   for (const artifact of [


### PR DESCRIPTION
## Summary

- replace the legacy single-mode `vibration` viewer path from PRs #71/#72 with the reviewed all-mode API: `view(hess, normal_modes="all")`
- add mode selection, signed/imaginary frequencies, phase and amplitude controls, speed control, displacement arrows, symmetric animation, and displaced-geometry XYZ export
- validate and encode normal-mode payloads safely, avoid implicit Hessian calculations, and keep scalar-field and normal-mode rendering mutually exclusive
- add an optimized H₂O RHF/STO-3G example and user-guide documentation

## Validation

- `pytest tests/test_visualization.py tests/test_ir.py -q` — 46 passed
- Ruff — passed
- H₂O headless example — 2169.85, 4139.63, 4390.67 cm⁻¹
- ESLint — passed
- viewer tests — 11 passed
- full production Next.js build/typecheck/static export — passed