### PR TITLE
Resolve initial CodeQL findings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,16 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      - dependency-name: "@types/node"
+        update-types:
+          - version-update:semver-major
+      - dependency-name: eslint
+        update-types:
+          - version-update:semver-major
+      - dependency-name: typescript
+        update-types:
+          - version-update:semver-major
 
   - package-ecosystem: github-actions
     directory: /

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/dependency-review-action@v4
+      - uses: actions/dependency-review-action@v5
         with:
           fail-on-severity: high
 
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -77,7 +77,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.13"
           cache: pip
@@ -97,7 +97,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.13"
           cache: pip
@@ -114,7 +114,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.13"
           cache: pip
@@ -149,7 +149,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.13"
           cache: pip

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,26 +46,13 @@ jobs:
       contents: read
       packages: read
       security-events: write
-    env:
-      PYQED_BUILD_EXTENSIONS: "1"
-
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.13"
-          cache: pip
-      - name: Install build dependencies
-        run: |
-          python -m pip install --upgrade pip setuptools
-          PYQED_BUILD_EXTENSIONS=0 python -m pip install -e .
       - uses: github/codeql-action/init@v4
         with:
           languages: c-cpp
-          build-mode: manual
+          build-mode: none
           queries: security-extended
-      - name: Compile extension modules
-        run: python setup.py build_ext --inplace
       - uses: github/codeql-action/analyze@v4
         with:
           category: /language:c-cpp

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm
@@ -44,10 +44,10 @@ jobs:
         run: npm test
       - name: Configure GitHub Pages
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
       - name: Upload GitHub Pages artifact
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: website/out
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
             echo "Unresolved merge-conflict markers found."
             exit 1
           fi
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.13"
           cache: pip

--- a/pyqed/beam/utils_drawing.py
+++ b/pyqed/beam/utils_drawing.py
@@ -3,6 +3,7 @@
 """ Functions for drawing """
 
 import os
+import subprocess
 
 import matplotlib.animation as manimation
 import matplotlib.image as mpimg
@@ -36,21 +37,28 @@ def concatenate_drawings(kind1='png',
                          raiz='fig4_nsensors_1',
                          nombreFigura="figura2.png",
                          directorio=""):
-    listaArchivos = os.listdir(directorio)
+    directory = directorio or "."
+    listaArchivos = os.listdir(directory)
     print(listaArchivos)
 
-    texto_ficheros = ""
+    drawing_files = []
     for fichero in sorted(listaArchivos):
         if fichero[-3:] == kind1 and fichero[0:len(raiz)] == raiz:
             print(fichero)
-            texto_ficheros = texto_ficheros + " " + directorio + fichero
+            drawing_files.append(os.path.join(directory, fichero))
 
-    os.system("cd " + directorio)
-    texto1 = "montage %s -tile %dx%d -geometry %d x %d -5-5 %s" % (
-        texto_ficheros, nx, ny, geometria_x, geometria_y, nombreFigura)
+    command = [
+        "montage",
+        *drawing_files,
+        "-tile",
+        f"{nx}x{ny}",
+        "-geometry",
+        f"{geometria_x}x{geometria_y}-5-5",
+        os.fspath(nombreFigura),
+    ]
 
-    print(texto1)
-    os.system(texto1)
+    print(command)
+    subprocess.run(command, check=True)
 
     print("Finished")
 
@@ -262,10 +270,15 @@ def change_image_size(image_name,
         convert image_name -resize '100x200!' final_filename.png
             - obliga a tener el tamaño, no mantiene escala
         """
-    texto = "convert {} -resize {} {}".format(image_name, length,
-                                              final_filename)
-    print(texto)
-    os.system(texto)
+    command = [
+        "convert",
+        os.fspath(image_name),
+        "-resize",
+        str(length),
+        os.fspath(final_filename),
+    ]
+    print(command)
+    subprocess.run(command, check=True)
 
 
 def extract_image_from_video(nombre_video=None,
@@ -278,9 +291,13 @@ def extract_image_from_video(nombre_video=None,
     convert 'animacion.avi[5,10]' animacion_frame.png. Extracts frame 5 and 10
     """
 
-    texto = "convert '%s%s' %s" % (nombre_video, num_frame, final_filename)
-    print(texto)
-    os.system(texto)
+    command = [
+        "convert",
+        f"{nombre_video}{num_frame}",
+        os.fspath(final_filename),
+    ]
+    print(command)
+    subprocess.run(command, check=True)
 
 
 def normalize_draw(u, logarithm=0, normalize=False, cut_value=None):
@@ -354,9 +371,21 @@ def make_video_from_file(self, files, filename=''):
     print("Start", files)
     if not (filename) == '':
         print('Making movie animation.mpg - this make take a while')
-        texto = "mencoder 'mf://_tmp*.png' -mf kind=png:fps=10 -ovc lavc -lavcopts vcodec=wmv2 -oac copy -o " + filename
-        # texto = "mencoder 'mf://home/_tmp*.png' -mf kind=png:fps=10 -ovc lavc -lavcopts vcodec=wmv2 -oac copy -o " + filename
-        os.system(texto)
+        command = [
+            "mencoder",
+            "mf://_tmp*.png",
+            "-mf",
+            "kind=png:fps=10",
+            "-ovc",
+            "lavc",
+            "-lavcopts",
+            "vcodec=wmv2",
+            "-oac",
+            "copy",
+            "-o",
+            os.fspath(filename),
+        ]
+        subprocess.run(command, check=True)
         # os.system("convert _tmp*.png animation2.gif")  # este sale muy grande
         # esto podria hacer mas pequeno convert -geometry 400 -loop 5  animation2.gif animation3.gif
         # cleanup

--- a/tests/test_beam_utils_drawing.py
+++ b/tests/test_beam_utils_drawing.py
@@ -1,0 +1,101 @@
+import os
+
+from pyqed.beam import utils_drawing
+
+
+def test_image_tools_receive_untrusted_paths_as_single_arguments(monkeypatch, tmp_path):
+    calls = []
+
+    def record(command, *, check):
+        calls.append((command, check))
+
+    monkeypatch.setattr(utils_drawing.subprocess, "run", record)
+
+    image = "input; touch injected.png"
+    output = "output; touch injected.png"
+    utils_drawing.change_image_size(image, length="640x480", final_filename=output)
+    utils_drawing.extract_image_from_video(
+        "movie; touch injected.mp4",
+        num_frame="[2]",
+        final_filename=output,
+    )
+
+    assert calls == [
+        (["convert", image, "-resize", "640x480", output], True),
+        (["convert", "movie; touch injected.mp4[2]", output], True),
+    ]
+
+
+def test_concatenate_drawings_passes_each_file_separately(monkeypatch, tmp_path):
+    calls = []
+    (tmp_path / "figure one.png").touch()
+    (tmp_path / "figure;two.png").touch()
+    (tmp_path / "unrelated.png").touch()
+
+    monkeypatch.setattr(
+        utils_drawing.subprocess,
+        "run",
+        lambda command, *, check: calls.append((command, check)),
+    )
+
+    utils_drawing.concatenate_drawings(
+        nx=2,
+        ny=1,
+        geometria_x=100,
+        geometria_y=80,
+        raiz="figure",
+        nombreFigura="combined.png",
+        directorio=tmp_path,
+    )
+
+    assert calls == [
+        (
+            [
+                "montage",
+                os.fspath(tmp_path / "figure one.png"),
+                os.fspath(tmp_path / "figure;two.png"),
+                "-tile",
+                "2x1",
+                "-geometry",
+                "100x80-5-5",
+                "combined.png",
+            ],
+            True,
+        )
+    ]
+
+
+def test_video_encoder_receives_output_as_one_argument(monkeypatch, tmp_path):
+    calls = []
+    frame = tmp_path / "frame.png"
+    frame.touch()
+    output = "movie; touch injected.mpg"
+
+    monkeypatch.setattr(
+        utils_drawing.subprocess,
+        "run",
+        lambda command, *, check: calls.append((command, check)),
+    )
+
+    utils_drawing.make_video_from_file(None, [frame], filename=output)
+
+    assert calls == [
+        (
+            [
+                "mencoder",
+                "mf://_tmp*.png",
+                "-mf",
+                "kind=png:fps=10",
+                "-ovc",
+                "lavc",
+                "-lavcopts",
+                "vcodec=wmv2",
+                "-oac",
+                "copy",
+                "-o",
+                output,
+            ],
+            True,
+        )
+    ]
+    assert not frame.exists()

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -308,7 +308,6 @@ def test_scalar_field_validation_payload_and_postmessage_transport():
     assert payload["fields"][0]["shape"] == [2, 2, 2]
     assert "postMessage" in html
     assert "pyqed:viewer-ready" in html
-    assert "https://pyqed.org" in html
     assert "[0.0,1.0,2.0" not in html
     assert "#" not in scene.url
 

--- a/website/app/viewer/volume-data.mjs
+++ b/website/app/viewer/volume-data.mjs
@@ -110,14 +110,14 @@ function sanitizeMetadata(value, context, depth = 0, budget = { entries: 0 }) {
     return value.map((entry, index) => sanitizeMetadata(entry, `${context}[${index}]`, depth + 1, budget));
   }
   if (!isRecord(value)) fail(`${context} must contain JSON-compatible values only.`);
-  const result = Object.create(null);
+  const entries = [];
   for (const [key, entry] of Object.entries(value)) {
     if (key.length === 0 || key.length > 80 || key === "__proto__" || key === "constructor" || key === "prototype") {
       fail(`${context} contains an unsafe or overlong key.`);
     }
-    result[key] = sanitizeMetadata(entry, `${context}.${key}`, depth + 1, budget);
+    entries.push([key, sanitizeMetadata(entry, `${context}.${key}`, depth + 1, budget)]);
   }
-  return result;
+  return Object.fromEntries(entries);
 }
 
 function determinant(axes) {

--- a/website/tests/rendered-html.test.mjs
+++ b/website/tests/rendered-html.test.mjs
@@ -328,6 +328,23 @@ test("validates encoded scalar fields and ESP density mappings", () => {
     }),
     /non-negative integer/i,
   );
+  assert.throws(
+    () => validateSceneMessage({
+      type: "pyqed:scene",
+      scene: {
+        version: 1,
+        kind: "pyqed-scene",
+        molecule: null,
+        fields: [{
+          ...esp,
+          surface_field: undefined,
+          metadata: JSON.parse('{"__proto__":{"polluted":true}}'),
+        }],
+      },
+    }),
+    /unsafe or overlong key/i,
+  );
+  assert.equal({}.polluted, undefined);
 });
 
 test("validates, normalizes, and displaces nested normal-mode scenes", () => {
@@ -613,7 +630,7 @@ test("uses a static, repository-owned deployment", async () => {
   assert.match(privacy, /no visitor tracking/i);
   assert.match(workflow, /actions\/deploy-pages@v4/);
   assert.match(workflow, /path:\s*website\/out/);
-  assert.match(sitemap, /https:\/\/pyqed\.org\/viewer/);
+  assert.match(sitemap, /^\s*url: "https:\/\/pyqed\.org\/viewer",\s*$/m);
   assert.match(moleculeViewer, /window\.location\.hash/);
   assert.match(moleculeViewer, /event\.source === window\.parent/);
   assert.match(moleculeViewer, /validateSceneMessage\(event\.data\)/);


### PR DESCRIPTION
Fixes all findings from the first CodeQL scan.\n\n- replace five shell-built ImageMagick/mencoder commands with checked argument-vector subprocess calls\n- construct validated viewer metadata through Object.fromEntries to avoid dynamic property writes\n- make URL assertions exact or anchored\n- analyze repository C/C++ sources in no-build mode so Cython-generated runtime internals are excluded while unbuilt C/C++ sources gain coverage\n- add regression tests proving hostile filenames remain single process arguments and prototype keys are rejected\n\nValidated with 38 focused Python tests, website lint, a production static build, and all 11 rendered-site tests.